### PR TITLE
Add Spanish localization.

### DIFF
--- a/qt/py/ui_AboutDialog.py
+++ b/qt/py/ui_AboutDialog.py
@@ -84,13 +84,13 @@ class AboutNUSGet(QDialog):
         title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # NUSGet Version
-        version_label = QLabel(self.tr("Version {nusget_version}".format(nusget_version=versions[0])))
+        version_label = QLabel(self.tr("Version {nusget_version}").format(nusget_version=versions[0]))
         version_label.setProperty("class", "version")
         version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # Library Versions
-        libraries_label = QLabel(self.tr("Using libWiiPy {libwiipy_version} & libTWLPy {libtwlpy_version}"
-                                         .format(libwiipy_version=versions[1], libtwlpy_version=versions[2])))
+        libraries_label = QLabel(self.tr("Using libWiiPy {libwiipy_version} & libTWLPy {libtwlpy_version}")
+                                         .format(libwiipy_version=versions[1], libtwlpy_version=versions[2]))
         libraries_label.setProperty("class", "version")
         libraries_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
@@ -145,7 +145,9 @@ class AboutNUSGet(QDialog):
             "rolfiee": QLabel(self.tr(
                 "Norwegian (Norsk): <a href=https://github.com/rolfiee style='color: #4a86e8; text-decoration: none;'><b>rolfiee</b></a>")),
             "NotImplementedLife": QLabel(self.tr(
-                "Romanian (Rom\u00e2n\u0103): <a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'><b>NotImplementedLife</b></a>"))
+                "Romanian (Rom\u00e2n\u0103): <a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'><b>NotImplementedLife</b></a>")),
+            "DarkMatterCore": QLabel(self.tr(
+                "Spanish (Español): <a href=https://github.com/DarkMatterCore style='color: #4a86e8; text-decoration: none;'><b>DarkMatterCore</b></a>"))
         }
 
         # Add team members to layout

--- a/resources/translations/nusget_de.ts
+++ b/resources/translations/nusget_de.ts
@@ -69,6 +69,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Rumänisch (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -87,246 +92,246 @@ Titel, welche in der Liste mit einem Haken markiert sind, haben ein frei verfüg
 Standartmäßig werden alle Inhalte und Archive in einen &quot;NUSGet Downloads&quot;-Ordner im Downloads-Order gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Als installierbares Archiv verpacken (WAD/TAD)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translatorcomment>&quot;speichern&quot; is more like &quot;save&quot; than &quot;keep&quot;, but &quot;behalten&quot; would sound stupid</translatorcomment>
         <translation>Verschlüsselte Inhalte speichern</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translatorcomment>Similar situation as with &quot;Keep encrypted contents&quot;, means more like &quot;Decrypt contents&quot; because it sounds better</translatorcomment>
         <translation>Inhalte entschlüsseln (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Vorhandene Dateien nutzen, sofern verfügbar</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Wii U-NUS benutzen (schneller, betrifft nur Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Patches für IOS anwenden (Betrifft nur WADs)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Inhalte des Titels mit dem Wii Common-Key neu verschlüsseln</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>Beim Start nach Updates suchen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>Benutzerspezifischen Downloads-Ordner nutzen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>NUSGet-Update verfügbar</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Eine neue version von NUSGet ist verfügbar!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translatorcomment>&quot;Output&quot; is quite difficult to translate into anything sensical, so I added &quot;format&quot; to make it specifically refer to the type of output the user wants, which keeps it consistent with the rest of the text</translatorcomment>
         <translation>Kein Ausgabeformat ausgewählt</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Es wurde kein Ausgabeformat für die Inhalte ausgewählt!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Bitte wählen Sie mindestens ein Format aus für den herunterzuladenen Titel.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>Fehlerhafter Downloads-Ordner</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>Der ausgewählte Downloads-Ordner konnte nicht gefunden werden!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>Bitte stellen Sie sicher, dass der Downloads-Ordner existiert und dass Sie Zugriff auf diesen haben.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>Fehlerhafte Title-ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Die angegebene Title-ID ist fehlerhaft!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Title-IDs müssen aus 16 alphanumerischen Zeichen bestehen. Bitte geben Sie eine korrekte Title-ID ein oder wählen Sie einen Titel aus der Liste links.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>Title-ID/Version nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Es konnte kein Titel mit der gegebenen Title-ID bzw. Version gefunden werden!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Bitte stellen Sie sicher, dass Sie eine korrekte Title-ID eingegeben haben und dass die Version auch existiert. Alternativ können Sie diese auch in der Liste links finden.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Inhaltsentschlüsselung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Die Inhalte konnten nicht entschlüsselt werden.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>Das TMD oder Ticket könnten wohlmöglich beschädigt sein oder stimmen nicht mit dem ausgewählten Titel überein, sofern &quot;Vorhandene Dateien nutzen, sofern verfügbar&quot; aktiviert wurde. Im letzteren Fall sollten Sie versuchen, diese Option auszuschalten und die Inhalte neu herunterzuladen.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Ticket nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Es konnte kein Ticket für den angegebenen TItel gefunden werden!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>Es konnte kein Ticket für den ausgewählten Titel heruntergeladen werden, jedoch wurde &quot;Als installierbares Archiv verpacken&quot; bzw. &quot;Inhalte entschlüsseln&quot; ausgewählt. Diese Optionen erfordern ein Ticket. Es wurden nur verschlüsselte Inhalte gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ein unbekannter Fehler ist aufgetreten!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Bitte versuchen Sie noch einmal. Sofern das Problem weiter besteht, wenden Sie sich bitte an den Issue-Tracker auf GitHub mit Details dazu, was Sie versucht haben.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Script-Fehler aufgetreten</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Fehler sind während der Ausführung von Scripten aufgetreten.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Bitte schauen Sie im Log nach, welche Fehler aufgetreten sind.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>Die angegebenen Titel konnten wegen Fehlern nicht heruntergeladen werden. Bitte stellen Sie sicher, dass die Title-IDs und Versionen im Script korrekt sind.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>Sie haben &quot;Inhalte entschlüsseln&quot; bzw. &quot;Als installierbares Archiv verpacken&quot; ausgewählt, aber die angegebenen Titel im Script haben kein verfügbares Ticket. Sofern &quot;Verschlüsselte Inhalte speichern&quot; aktiv ist, wurden verschlüsselte Daten noch gespeichert.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Script-Download fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>NUS-Script öffnen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>NUS-Scripts (*.nus *.json)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ein Fehler ist beim Lesen des Scripts aufgetreten!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation>Der Fehler ist bei Linie {e.lineno}, Zeile {e.colno} aufgetreten. Bitte überprüfen Sie ihr Script und versuchen Sie es erneut.</translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>Der Fehler ist bei Linie {lineno}, Zeile {colno} aufgetreten. Bitte überprüfen Sie ihr Script und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ein Fehler ist beim Lesen der Title-IDs aufgetreten!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>Der Titel an Stelle {script_data.index(title)} hat keine Title-ID!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>Der Titel an Stelle {index} hat keine Title-ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>Ordner öffnen</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Der angegebene Downloads-Ordner konnte nicht gefunden werden!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>Bitte stellen Sie sicher, dass der Downloads-Ordner, den Sie nutzen möchten, existiert und dass Sie darauf auch Zugriffen haben.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
@@ -335,7 +340,7 @@ Could not check for updates.</source>
 Konnte nicht nach Updates suchen.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
@@ -344,7 +349,7 @@ There&apos;s a newer version of NUSGet available!</source>
 Eine neuere Version von NUSGet ist verfügbar!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>

--- a/resources/translations/nusget_es.ts
+++ b/resources/translations/nusget_es.ts
@@ -6,67 +6,73 @@
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="16"/>
         <source>About NUSGet</source>
-        <translation type="unfinished"></translation>
+        <translation>Acerca de NUSGet</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="82"/>
         <source>NUSGet</source>
-        <translation type="unfinished"></translation>
+        <translation>NUSGet</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="87"/>
         <source>Version {nusget_version}</source>
-        <translation type="unfinished"></translation>
+        <translation>Versión {nusget_version}</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="93"/>
         <source>Using libWiiPy {libwiipy_version} &amp; libTWLPy {libtwlpy_version}</source>
-        <translation type="unfinished"></translation>
+        <translation>Usando libWiiPy {libwiipy_version} y libTWLPy {libtwlpy_version}</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="98"/>
         <source>© 2024-2025 NinjaCheetah &amp; Contributors</source>
-        <translation type="unfinished"></translation>
+        <translation>© 2024-2025 NinjaCheetah y colaboradores</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="114"/>
         <source>View Project on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver proyecto en GitHub</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="130"/>
         <source>Translations</source>
-        <translation type="unfinished"></translation>
+        <translation>Traducciones</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="138"/>
         <source>French (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Francés (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="140"/>
         <source>German (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Alemán (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="142"/>
         <source>Italian (Italiano): &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Italiano&quot; is spelled the same way in both Italian and Spanish.</translatorcomment>
+        <translation>Italiano: &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="144"/>
         <source>Korean (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Coreano (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="146"/>
         <source>Norwegian (Norsk): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Noruego (Norsk): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../qt/py/ui_AboutDialog.py" line="148"/>
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Rumano (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Español: &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
@@ -75,7 +81,7 @@
         <location filename="../../qt/ui/MainMenu.ui" line="90"/>
         <source>Wii</source>
         <translatorcomment>Does not change.</translatorcomment>
-        <translation type="unfinished">Wii</translation>
+        <translation>Wii</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="100"/>
@@ -98,47 +104,47 @@
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="26"/>
         <source>MainWindow</source>
-        <translation type="unfinished"></translation>
+        <translation>VentanaPrincipal</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="46"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Buscar</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="59"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Limpiar</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="135"/>
         <source>Title ID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID de título</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="155"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Versión</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="162"/>
         <source>Console:</source>
-        <translation type="unfinished"></translation>
+        <translation>Consola:</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="198"/>
         <source>Start Download</source>
-        <translation type="unfinished"></translation>
+        <translation>Iniciar descarga</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="211"/>
         <source>Run Script</source>
-        <translation type="unfinished"></translation>
+        <translation>Ejecutar script</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="238"/>
         <source>General Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración general</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="425"/>
@@ -150,173 +156,174 @@ li.unchecked::marker { content: &quot;\2610&quot;; }
 li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.AppleSystemUIFont&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="464"/>
         <source>About NUSGet</source>
-        <translation type="unfinished"></translation>
+        <translation>Acerca de NUSGet</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
-        <translation type="unfinished"></translation>
+        <translation>Generar paquete de instalación (WAD/TAD)</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="251"/>
         <source>File Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de archivo</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantener contenidos encriptados</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear contenidos desencriptados (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar archivos locales, si existen</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="324"/>
         <source>vWii Title Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración de títulos de vWii</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Reencriptar título usando la clave común de Wii</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="343"/>
         <source>App Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración de aplicación</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Buscar actualizaciones al inicio</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar ruta de descarga personalizada</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="371"/>
         <source>Select...</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar...</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="451"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayuda</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="475"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>Acerca de Qt</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="361"/>
         <source>Output Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruta de descarga</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
-        <translation type="unfinished"></translation>
+        <translation>Aplicar parches a IOS (sólo aplica a WADs)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualización de NUSGet disponible</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato de salida no escogido</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
-        <translation type="unfinished"></translation>
+        <translation>¡No has escogido un formato de salida para los datos!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, selecciona al menos un formato de salida para la descarga.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Directorio de descarga inválido</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
-        <translation type="unfinished"></translation>
+        <translation>¡El directorio de descarga especificado no existe!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, asegúrate de que el directorio de descarga especificado existe, y de que tengas permisos para acceder a él.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../NUSGet.py" line="384"/>
-        <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../NUSGet.py" line="389"/>
-        <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>ID de título inválido</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="394"/>
+        <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;¡El ID de título introducido no tiene un formato válido!&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../NUSGet.py" line="399"/>
+        <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;¡No se encontró un título que coincida con el ID de título y/o versión proporcionados!&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;¡El desencriptado de contenidos falló! No se han podido crear los contenidos desencriptados.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Ticket&quot; may be translated as &quot;billete&quot;, &quot;boleto&quot; or even &quot;tique&quot;, but it is preferable to use the English term here for consistency&apos;s sake.</translatorcomment>
+        <translation>&lt;b&gt;¡No existe un ticket disponible para el título solicitado!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;¡Ha ocurrido un error desconocido!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../NUSGet.py" line="479"/>
-        <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Ocurrieron algunos problemas durante la ejecución del script de descarga.&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="489"/>
-        <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;¡Ocurrió un error mientras se analizaba el archivo de script!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="500"/>
+        <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;¡Ocurrió un error mientras se analizaban los IDs de títulos!&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
-        <translation type="unfinished"></translation>
+        <translation>Los IDs de títulos tienen que ser cadenas alfanuméricas de 16 dígitos. Por favor, introduce un ID de título con el formato apropiado, o selecciona uno desde el menú a la izquierda.</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="119"/>
@@ -325,138 +332,152 @@ li.checked::marker { content: &quot;\2612&quot;; }
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
 By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&quot; inside your downloads folder.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Ticket&quot; may be translated as &quot;billete&quot;, &quot;boleto&quot; or even &quot;tique&quot;, but it is preferable to use the English term here for consistency&apos;s sake.</translatorcomment>
+        <translation>Selecciona un título desde la lista a la izquierda, o introduce un ID de título para empezar.
+
+Los títulos con una marca de verificación son gratuitos, tienen un ticket disponible y pueden ser desencriptados y/o empaquetados a un WAD o TAD. Los títulos con una &quot;X&quot; no cuentan con un ticket, y sólo pueden guardarse sus contenidos encriptados.
+
+Por defecto, los títulos serán descargados a una carpeta llamada &quot;NUSGet Downloads&quot; dentro de tu directorio de descargas.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar NUS de Wii U (más rápido, sólo afecta a Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;¡Hay una nueva versión de NUSGet disponible!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
-        <translation type="unfinished"></translation>
+        <translation>ID de título / versión no disponible</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, asegúrate de haber introducido un ID de título válido o de seleccionar uno de la base de datos de títulos, y que la versión proporcionada existe para el título que estás tratando de descargar.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>El desencriptado de contenidos falló</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Ticket&quot; may be translated as &quot;billete&quot;, &quot;boleto&quot; or even &quot;tique&quot;, but it is preferable to use the English term here for consistency&apos;s sake.</translatorcomment>
+        <translation>Tu TMD o ticket puede estar dañado, o puede que no correspondan al contenido que está siendo desencriptado. Si marcaste la casilla &quot;Usar archivos locales, si existen&quot;, prueba con desactivar dicha opción antes de intentar nuevamente la descarga para corregir posibles problemas con los datos locales.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Ticket&quot; may be translated as &quot;billete&quot;, &quot;boleto&quot; or even &quot;tique&quot;, but it is preferable to use the English term here for consistency&apos;s sake.</translatorcomment>
+        <translation>Ticket no disponible</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>&quot;Ticket&quot; may be translated as &quot;billete&quot;, &quot;boleto&quot; or even &quot;tique&quot;, but it is preferable to use the English term here for consistency&apos;s sake.</translatorcomment>
+        <translation>No se pudo descargar un ticket para el título solicitado, pero has marcado la casilla &quot;Generar paquete de instalación&quot; o &quot;Crear contenidos desencriptados&quot;. Estas opciones no están disponibles para títulos sin un ticket. Sólo se han guardado los contenidos encriptados.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error desconocido</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../NUSGet.py" line="428"/>
-        <source>Script Issues Occurred</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../NUSGet.py" line="431"/>
-        <source>Check the log for more details about what issues were encountered.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, intenta de nuevo. Si el problema persiste, por favor abre un reporte de problema en GitHub detallando lo que intentabas hacer cuando ocurrió este error.</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="438"/>
-        <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
-        <translation type="unfinished"></translation>
+        <source>Script Issues Occurred</source>
+        <translation>Ocurrieron problemas con el script</translation>
+    </message>
+    <message>
+        <location filename="../../NUSGet.py" line="441"/>
+        <source>Check the log for more details about what issues were encountered.</source>
+        <translation>Lee el registro para obtener más detalles sobre los problemas que se encontraron.</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="448"/>
+        <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
+        <translation>Los siguientes títulos no pudieron ser descargados debido a un error. Por favor, asegúrate de que el ID de título y la versión listados en el script son válidos.</translation>
+    </message>
+    <message>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
-        <translation type="unfinished"></translation>
+        <translation>Marcaste la casilla &quot;Crear contenidos desencriptados&quot; o &quot;Generar paquete de instalación&quot;, pero los siguientes títulos del script no tienen un ticket disponible. Si se marcó su opción, los contenidos encriptados fueron descargados de todas maneras.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>La descarga del script falló</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir script de NUS</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
-        <translation type="unfinished"></translation>
+        <translation>Scripts de NUS (*.nus, *.json)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>Error encontrado en la línea {lineno}, columna {colno}. Por favor, verifica el script e intenta nuevamente.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>¡El título con índice {index} no tiene un ID de título!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir directorio</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;¡El directorio de descarga especificado no existe!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, asegúrate de que el directorio de descarga especificado existe, y de que tengas permisos para acceder a él.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+No se pudo buscar actualizaciones.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+¡Hay una nueva versión de NUSGet disponible!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+Estás usando el lanzamiento más reciente de NUSGet.</translation>
     </message>
 </context>
 </TS>

--- a/resources/translations/nusget_fr.ts
+++ b/resources/translations/nusget_fr.ts
@@ -69,6 +69,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Roumain (Română) : &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -95,7 +100,7 @@ Les titres marqués d&apos;une coche sont gratuits et ont un billet disponible, 
 Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, à l&apos;intérieur de votre dossier de téléchargements.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="238"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>Mise à jour NUSGet disponible</translation>
     </message>
@@ -117,88 +122,88 @@ Les titres marqués d&apos;une coche sont gratuits et ont un billet disponible, 
 Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, à l&apos;intérieur de votre dossier de téléchargements.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="169"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Utiliser le NUS Wii U (plus rapide, n&apos;affecte que Wii / vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="239"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Une nouvelle version de NUSGet est disponible !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="340"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>Aucun format sélectionné</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="341"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Veuillez sélectionner un format de sortie pour les données !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="343"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Veuillez sélectionner au moins une option de téléchargement.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="355"/>
-        <location filename="../../NUSGet.py" line="559"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>Dossier de téléchargement invalide</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="356"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>Le dossier de téléchargement choisi n&apos;existe pas !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>Assurez-vous que votre dossier de téléchargement existe, et que vous avez les droits suffisants pour y accéder.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>ID de titre invalide</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="390"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt;L&apos;ID de titre que vous avez saisi a un format invalide !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="395"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Aucun titre trouvé pour l&apos;ID ou la version fourni !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Le décryptage du contenu a échoué ! Le contenu décrypté ne peut être créé.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Aucun billet disponible pour le titre demandé !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="413"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Une erreur inconnue est survenue !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="435"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Des erreurs sont survenues pendant l&apos;exécution du script de téléchargement.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="485"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Une erreur est survenue pendant la lecture du script !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="495"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Une erreur est survenue à la lecture d&apos;un ID de titre !&lt;/b&gt;</translation>
     </message>
@@ -207,12 +212,12 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">L&apos;ID de titre que vous avez saisi a un format invalide !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="392"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Les ID de titre doivent être composés de 16 caractères alphanumériques. Veuillez saisir un ID formaté correctement, ou sélectionnez-en un depuis le menu de gauche.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>ID de titre / Version introuvable</translation>
     </message>
@@ -221,12 +226,12 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Aucun titre trouvé pour l&apos;ID ou la version fourni !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Veuillez vous assurez que vous avez saisi un ID valide, ou sélectionnez-en un depuis la base de données, et que la version fournie existe pour le titre que vous souhaitez télécharger.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="399"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Échec du décryptage</translation>
     </message>
@@ -235,12 +240,12 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Le décryptage du contenu a échoué ! Le contenu décrypté ne peut être créé.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="403"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>Vos métadonnées (TMD) ou le billet sont probablement endommagés, ou ils ne correspondent pas au contenu décrypté. Si vous avez coché &quot;Utiliser des fichiers locaux, s&apos;ils existent&quot;, essayez de désactiver cette option avant d&apos;essayer à nouveau pour résoudre les éventuelles erreurs avec les données locales.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Billet indisponible</translation>
     </message>
@@ -249,12 +254,12 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Aucun billet disponible pour le titre demandé !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="410"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>Un billet ne peut être téléchargé pour le titre demandé, mais vous avez sélectionné &quot;Empaqueter une archive d&apos;installation&quot; ou &quot;Décrypter le contenu&quot;. Ces options sont indisponibles pour les titres sans billet. Seul le contenu crypté a été enregistré.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="412"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Erreur inconnue</translation>
     </message>
@@ -263,12 +268,12 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Une erreur inconnue est survenue !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="415"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Veuillez essayer à nouveau. Si le problème persiste, déclarez un problème sur GitHub en décrivant les actions qui ont provoqué l&apos;erreur.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="434"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Erreurs survenues dans le script</translation>
     </message>
@@ -277,32 +282,32 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Des erreurs sont survenues pendant l&apos;exécution du script de téléchargement.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="437"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Vérifiez le journal pour plus de détails à propos des erreurs rencontrées.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="444"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>Le téléchargement des titres suivants a échoué. Assurez-vous que les ID de titre et version du script soient valides.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="454"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>Vous avez activé &quot;Décrypter le contenu&quot; ou &quot;Empaqueter une archive d&apos;installation&quot;, mais les billets des titres suivants sont indisponibles. Si activé(s), le contenu crypté a été téléchargé.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="473"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Échec du script de téléchargement</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="474"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>Ouvrir un script NUS</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="475"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>Scripts NUS (*.nus *.json)</translation>
     </message>
@@ -311,31 +316,31 @@ Les titres seront téléchargés dans un dossier &quot;NUSGet Downloads&quot;, �
         <translation type="vanished">Une erreur est survenue pendant la lecture du script !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="486"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation>Erreur recontrée ligne {e.lineno}, colonne {e.colno}. Vérifiez le script et réessayez.</translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>Erreur recontrée ligne {lineno}, colonne {colno}. Vérifiez le script et réessayez.</translation>
     </message>
     <message>
         <source>An error occurred while parsing Title IDs!</source>
         <translation type="vanished">Une erreur est survenue à la lecture d&apos;un ID de titre !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="496"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>Le titre à l&apos;index {script_data.index(title)} n&apos;a pas d&apos;ID !</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>Le titre à l&apos;index {index} n&apos;a pas d&apos;ID !</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="549"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>Ouvrir un dossier</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="560"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Le dossier de téléchargement choisi n&apos;existe pas !&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="563"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>Assurez-vous que votre dossier de téléchargement existe, et que vous avez les droits suffisants pour y accéder.</translation>
     </message>
@@ -422,7 +427,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>À propos de NUSGet</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Empaqueter une archive d&apos;installation (WAD / TAD)</translation>
     </message>
@@ -432,17 +437,17 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Nom du fichier</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>Conserver le contenu crypté</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>Décrypter le contenu (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Utiliser des fichiers locaux, s&apos;ils existent</translation>
     </message>
@@ -451,7 +456,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="vanished">Utiliser le NUS Wii U (plus rapide, n&apos;affecte que Wii / vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="171"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Appliquer des modifications aux IOS (WAD uniquement)</translation>
     </message>
@@ -461,7 +466,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Titres vWii</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="172"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Encrypter le titre avec la clé commune Wii</translation>
     </message>
@@ -471,12 +476,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="173"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>Vérifier les mises à jour au démarrage</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="174"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>Utiliser un dossier de téléchargement différent</translation>
     </message>

--- a/resources/translations/nusget_it.ts
+++ b/resources/translations/nusget_it.ts
@@ -68,6 +68,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -146,7 +151,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Archivio installabile (WAD/TAD)</translation>
     </message>
@@ -156,17 +161,17 @@
         <translation>Nome del file</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>Mantieni contenuti criptati</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>Crea contenuto decriptato (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Usa file locali, se esistenti</translation>
     </message>
@@ -180,7 +185,7 @@
         <translation>Impostazioni titoli vWii</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Cripta titolo usando la Chiave Comune Wii</translation>
     </message>
@@ -190,12 +195,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -293,88 +298,88 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>Nessun output selezionato</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Non hai selezionato alcun formato in cui esportare i dati!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Per favore scegli almeno un opzione per come vorresti che fosse salvato il download.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>ID Titolo invalido</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -383,12 +388,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">L&apos; ID Titolo che hai inserito non è in un formato valido!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Gli ID Titolo sono un codice di 16 caratteri tra numeri e lettere. Per favore inserisci in ID Titolo formattato correttamente, o scegline uno dal menù a sinistra.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>ID Titolo/Versione non trovata</translation>
     </message>
@@ -397,12 +402,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">Non è stato trovato nessun titolo con l&apos; ID Titolo o versione data!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Assicurati di aver inserito un&apos; ID Titolo valido, o scegline uno dal database, e che la versione richiesta esista per il titolo che vuoi scaricare.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Decriptazione contenuti fallita</translation>
     </message>
@@ -411,12 +416,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">La decriptazione dei contenuti non è andata a buon fine! I contenuti decriptadi non sono stati creati.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>Il tuo TMD o Ticket potrebbe essere danneggiato, o potrebbe non corrispondere col contenuto da decriptare. Se hai selezionato &quot;Usa file locali, se esistenti&quot;, prova a disabilitare quell&apos;opzione prima di riprovare a scaricare per aggiustare potenziali errori coi dati locali.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Ticket non disponibile</translation>
     </message>
@@ -425,12 +430,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">Nessun ticket disponibile per il titolo richiesto!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>Non è stato possibile scaricare un ticket per il titolo richiesto, ma hai selezionato &quot;Crea archivio installabile&quot; o &quot;Crea contenuto decriptato&quot;. Queste opzioni non sono disponibili per i titoli senza un ticket. Sono stati salvati solo i contenuti criptati.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Errore sconosciuto</translation>
     </message>
@@ -439,12 +444,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">Errore sconosciuto!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Per favore riprova. Se il problema persiste, apri un issue su GitHub specificando in modo dettagliato cosa volevi fare quando è comparso questo errore.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Errore script</translation>
     </message>
@@ -453,32 +458,32 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">Ci sono stati degli errori con lo script di download.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Guarda i log per più dettagli sull&apos;errore.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>I seguenti titoli non sono stati scaricati a causa di un errore. Controlla che l&apos;ID Titolo e la versione nello script siano validi.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Download script fallito</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>Apri script NUS</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>Scrpit NUS (*.nus *.txt)</translation>
     </message>
@@ -487,31 +492,31 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">Ci sono stati degli errori con lo script di download!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</translation>
     </message>
     <message>
         <source>An error occurred while parsing Title IDs!</source>
         <translation type="vanished">Ci sono stati degli errori con GLI id tITOLO!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>The title at index {script_data.index(title)} does not have a Title ID!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>The title at index {index} does not have a Title ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -553,12 +558,12 @@ I titoli marcati da una spunta sono disponibili e hanno un ticket libero, e poss
 I titoli verranno scaricati nella cartella &quot;NUSGet&quot; all&apos;interno della cartella Download.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Applica patch agli IOS (Solo per le WAD)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>Aggiornamento di NUSGet disponibile</translation>
     </message>
@@ -567,21 +572,21 @@ I titoli verranno scaricati nella cartella &quot;NUSGet&quot; all&apos;interno d
         <translation type="vanished">Una nuova versione di NUSGet è disponibile!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
         <translation>Impossibile trovare eventuali aggiornamenti.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
         <translation>Una nuova versione di NUSGet è disponibile!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>

--- a/resources/translations/nusget_ko.ts
+++ b/resources/translations/nusget_ko.ts
@@ -68,6 +68,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -146,7 +151,7 @@
         <translation type="unfinished">NUSGet 정보</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>설치 가능한 아카이브 (WAD/TAD) 팩</translation>
     </message>
@@ -156,17 +161,17 @@
         <translation>파일 이름</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>암호화된 내용 보관</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>복호화된 콘텐츠 (*.app) 생성</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>로컬 파일이 있으면 사용</translation>
     </message>
@@ -180,7 +185,7 @@
         <translation>vWii 타이틀 설정</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Wii 공통 키를 사용하여 타이틀을 다시 암호화</translation>
     </message>
@@ -190,12 +195,12 @@
         <translation>앱 설정</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>시작 시 업데이트 확인</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>커스텀 다운로드 디렉터리 사용</translation>
     </message>
@@ -301,88 +306,88 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
 기본적으로 타이틀은 다운로드 폴더 내의 &quot;NUSBet Downloads&quot; 폴더에 다운로드됩니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Wii U NUS 사용 (더 빠르고 Wii/vWii에만 효과 있음)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;NUSGet의 최신 버전이 출시되었습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>선택된 출력 없음</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>데이터를 출력할 형식을 선택하지 않았습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>다운로드를 저장할 방법을 하나 이상 선택하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>잘못된 다운로드 디렉터리</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>지정된 다운로드 디렉터리가 존재하지 않습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>지정된 다운로드 디렉터리가 있는지, 그리고 해당 디렉터리에 접근할 수 있는 권한이 있는지 확인하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>잘못된 제목 ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt;입력하신 타이틀 ID의 형식이 올바르지 않습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;제공된 타이틀 ID 또는 버전으로 제목을 찾을 수 없습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;콘텐츠 복호화에 실패했습니다! 복호화된 콘텐츠를 생성할 수 없습니다.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;요청하신 작품에 대한 티켓이 없습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;알 수 없는 오류가 발생했습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;다운로드 스크립트를 실행하는 동안 문제가 발생했습니다.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;스크립트 파일을 구문 분석하는 동안 오류가 발생했습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;타이틀 ID를 구문 분석하는 동안 오류가 발생했습니다!&lt;/b&gt;</translation>
     </message>
@@ -391,12 +396,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">입력한 타이틀 ID의 형식이 올바르지 않습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>타이틀 ID는 숫자와 문자로 구성된 16자리 문자열이어야 합니다. 올바르게 포맷된 타이틀 ID를 입력하거나 왼쪽 메뉴에서 하나를 선택하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>타이틀 ID/버전을 찾을 수 없음</translation>
     </message>
@@ -405,12 +410,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">제공된 타이틀 ID 또는 버전으로 제목을 찾을 수 없습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>유효한 타이틀 ID를 입력했는지 또는 타이틀 데이터베이스에서 선택했는지, 그리고 다운로드하려는 타이틀에 대해 제공된 버전이 있는지 확인하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>콘텐츠 복호화 실패</translation>
     </message>
@@ -419,12 +424,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">콘텐츠 복호화가 성공하지 못했습니다! 복호화된 콘텐츠를 만들 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>TMD 또는 티켓이 손상되었거나 복호화되는 콘텐츠와 일치하지 않을 수 있습니다. &quot;로컬 파일이 있으면 사용&quot;을 체크한 경우, 로컬 데이터와 관련된 잠재적인 문제를 해결하기 위해 다시 다운로드를 시도하기 전에 해당 옵션을 비활성화해 보세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>사용 가능한 티켓이 아님</translation>
     </message>
@@ -433,12 +438,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">요청한 타이틀에 대한 티켓이 없습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>요청한 타이틀에 대한 티켓을 다운로드할 수 없지만 &quot;설치 가능한 아카이브 팩&quot; 또는 &quot;암호 해독된 콘텐츠 생성&quot;을 선택했습니다. 이러한 옵션은 티켓이 없는 타이틀에는 사용할 수 없습니다. 암호화된 콘텐츠만 저장되었습니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>알 수 없는 오류</translation>
     </message>
@@ -447,12 +452,12 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">알 수 없는 오류가 발생했습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>다시 시도하세요. 이 문제가 지속되면 GitHub에서 새 이슈를 열어 이 오류가 발생했을 때 무엇을 하려고 했는지 자세히 설명하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>스크립트 문제가 발생함</translation>
     </message>
@@ -461,32 +466,32 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">다운로드 스크립트를 실행하는 동안 몇 가지 문제가 발생했습니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>발생한 문제에 대한 자세한 내용은 로그를 확인하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>다음 제목은 오류로 인해 다운로드할 수 없습니다. 스크립트에 나열된 타이틀 ID와 버전이 유효한지 확인하세요.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>&quot;암호 해독된 콘텐츠 만들기&quot; 또는 &quot;설치 가능한 아카이브 압축&quot;을 활성화했지만 스크립트의 다음 타이틀에는 사용 가능한 티켓이 없습니다. 활성화된 경우 암호화된 콘텐츠가 여전히 다운로드되었습니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>스크립트 다운로드 실패함</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>NUS 스크립트 열기</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>NUS 스크립트 (*.nus *.json)</translation>
     </message>
@@ -495,31 +500,31 @@ By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&q
         <translation type="vanished">스크립트 파일을 구문 분석하는 동안 오류가 발생했습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation>{e.lineno} 줄, {e.colno} 열에서 오류가 발생했습니다. 스크립트를 다시 확인하고 다시 시도하세요.</translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>{lineno} 줄, {colno} 열에서 오류가 발생했습니다. 스크립트를 다시 확인하고 다시 시도하세요.</translation>
     </message>
     <message>
         <source>An error occurred while parsing Title IDs!</source>
         <translation type="vanished">타이틀 ID를 구문 분석하는 동안 오류가 발생했습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>{script_data.index(title)} 인덱스의 타이틀에 타이틀 ID가 없습니다!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>{index} 인덱스의 타이틀에 타이틀 ID가 없습니다!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>디렉터리 열기</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;지정된 다운로드 디렉터리가 존재하지 않습니다!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>사용하려는 다운로드 디렉터리가 있는지, 그리고 해당 디렉터리에 접근할 수 있는 권한이 있는지 확인하세요.</translation>
     </message>
@@ -562,12 +567,12 @@ DSi 지원 : libTWLPy {libtwlpy_version}에서 제공
 타이틀은 다운로드 폴더 내의 &quot;NUSBet&quot;이라는 폴더에 다운로드됩니다.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>IOS에 패치 적용 (WAD에만 적용)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>NUSGet 업데이트 가능</translation>
     </message>
@@ -576,7 +581,7 @@ DSi 지원 : libTWLPy {libtwlpy_version}에서 제공
         <translation type="vanished">NUSBet의 새로운 버전이 나왔습니다!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
@@ -585,7 +590,7 @@ Could not check for updates.</source>
 업데이트를 확인할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
@@ -594,7 +599,7 @@ There&apos;s a newer version of NUSGet available!</source>
 NUSBet의 새로운 버전이 나왔습니다!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>

--- a/resources/translations/nusget_nb.ts
+++ b/resources/translations/nusget_nb.ts
@@ -68,6 +68,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -146,7 +151,7 @@
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Pakke installerbart arkiv (WAD/TAD)</translation>
     </message>
@@ -156,17 +161,17 @@
         <translation>Filnavn</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>Oppbevar kryptert innhold</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>Opprette dekryptert innold (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Bruk lokale filer, hvis de finnes</translation>
     </message>
@@ -180,7 +185,7 @@
         <translation>vWii Tittelinstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Krypter tittelen på nytt ved hjelp av Wii Common Key</translation>
     </message>
@@ -190,12 +195,12 @@
         <translation>Appinstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>Sjekk for oppdateringer ved oppstart</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>Bruke en egendefinert nedlastingsmappe</translation>
     </message>
@@ -314,83 +319,83 @@ Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypte
 Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det finnes en nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>Ingen Utgang Valgt</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Du ikke har valgt noe format å lagre dataene i!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Velg minst ett valg for hvordan du vil at nedlastingen skal lagres.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>Ugyldig Nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>Den angitte nedlastingsmappen finnes ikke!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>Ugyldig Tittel ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Tittel IDen du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen billett er tilgjengelig for den forespurte tittelen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;En ukjent feil har oppstått!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Noen feil oppstod under kjøring av nedlastingsskriptet.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av skriptfilen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av Tittel IDer!&lt;/b&gt;</translation>
     </message>
@@ -399,12 +404,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Tittel IDen du har angitt er ikke i et gyldig format!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Tittel IDer må være 16-sifrede tall og bokstav strenger. Vennligst skriv inn en korrekt formatert Tittel ID, eller velg en fra menyen til venstre.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>Tittel ID/Versjon Ikke Funnet</translation>
     </message>
@@ -413,12 +418,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Sjekk at du har oppgitt en gyldig Tittel ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Dekryptering av Innhold Mislyktes</translation>
     </message>
@@ -427,12 +432,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>TMDen eller Billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet some dekrypteres. Hvis du har krysset av for &quot;Bruk lokale filer, hvis de finnes&quot;, kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Billett Ikke Tilgjengelig</translation>
     </message>
@@ -441,12 +446,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Ingen billett er tilgjengelig for den forespurte tittelen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt &quot;Pakk installerbart arkiv&quot; eller &quot;Opprett dekryptert innhold&quot;. Disse alternativene er ikke tilgjenelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Ukjent Feil</translation>
     </message>
@@ -455,12 +460,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">En ukjent feil har oppstått!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne et nytt issue på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Skriptfeil Oppstod</translation>
     </message>
@@ -469,32 +474,32 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Noen feil oppstod under kjøring av nedlastingsskriptet.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Sjekk loggen for mer informasjon om feilene som har oppstått.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at Tittel IDen og versjon som er oppført i skriptet er gyldige.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>Du aktiverte &quot;Opprett dekryptert innhold&quot; eller &quot;Pakk installerbart archive&quot;, men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Skriptnedlasting Mislyktes</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>Åpne NUS Skript</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>NUS Skript (*.nus *.json)</translation>
     </message>
@@ -503,8 +508,8 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av skriptfilen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
         <translation></translation>
     </message>
     <message>
@@ -512,27 +517,27 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av Tittel IDer!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>Tittelen ved indeks {script_data.index(title)} har ikke en Tittel ID!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>Tittelen ved indeks {index} har ikke en Tittel ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>Åpen Mappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Den angitte nedlastingsmappen finnes ikke!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Påfør patcher på IOS (gjelder kun WADer)</translation>
     </message>
@@ -550,12 +555,12 @@ Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypte
 Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>NUSGet Oppdatering Tilgjengelig</translation>
     </message>
@@ -564,7 +569,7 @@ Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&q
         <translation type="vanished">Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
@@ -573,7 +578,7 @@ Could not check for updates.</source>
 Kunne ikke sjekke for oppdateringer.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
@@ -582,7 +587,7 @@ There&apos;s a newer version of NUSGet available!</source>
 Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>

--- a/resources/translations/nusget_no.ts
+++ b/resources/translations/nusget_no.ts
@@ -68,6 +68,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -146,7 +151,7 @@
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Pakke installerbart arkiv (WAD/TAD)</translation>
     </message>
@@ -156,17 +161,17 @@
         <translation>Filnavn</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>Oppbevar kryptert innhold</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>Opprette dekryptert innold (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Bruk lokale filer, hvis de finnes</translation>
     </message>
@@ -180,7 +185,7 @@
         <translation>vWii Tittelinstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Krypter tittelen på nytt ved hjelp av Wii Common Key</translation>
     </message>
@@ -190,12 +195,12 @@
         <translation>Appinstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>Sjekk for oppdateringer ved oppstart</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>Bruke en egendefinert nedlastingsmappe</translation>
     </message>
@@ -314,83 +319,83 @@ Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypte
 Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det finnes en nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>Ingen Utgang Valgt</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Du ikke har valgt noe format å lagre dataene i!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Velg minst ett valg for hvordan du vil at nedlastingen skal lagres.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>Ugyldig Nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>Den angitte nedlastingsmappen finnes ikke!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>Ugyldig Tittel ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Tittel IDen du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen billett er tilgjengelig for den forespurte tittelen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;En ukjent feil har oppstått!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Noen feil oppstod under kjøring av nedlastingsskriptet.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av skriptfilen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av Tittel IDer!&lt;/b&gt;</translation>
     </message>
@@ -399,12 +404,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Tittel IDen du har angitt er ikke i et gyldig format!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Tittel IDer må være 16-sifrede tall og bokstav strenger. Vennligst skriv inn en korrekt formatert Tittel ID, eller velg en fra menyen til venstre.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>Tittel ID/Versjon Ikke Funnet</translation>
     </message>
@@ -413,12 +418,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Sjekk at du har oppgitt en gyldig Tittel ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Dekryptering av Innhold Mislyktes</translation>
     </message>
@@ -427,12 +432,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>TMDen eller Billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet some dekrypteres. Hvis du har krysset av for &quot;Bruk lokale filer, hvis de finnes&quot;, kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Billett Ikke Tilgjengelig</translation>
     </message>
@@ -441,12 +446,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Ingen billett er tilgjengelig for den forespurte tittelen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt &quot;Pakk installerbart arkiv&quot; eller &quot;Opprett dekryptert innhold&quot;. Disse alternativene er ikke tilgjenelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Ukjent Feil</translation>
     </message>
@@ -455,12 +460,12 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">En ukjent feil har oppstått!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne et nytt issue på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Skriptfeil Oppstod</translation>
     </message>
@@ -469,32 +474,32 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Noen feil oppstod under kjøring av nedlastingsskriptet.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Sjekk loggen for mer informasjon om feilene som har oppstått.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at Tittel IDen og versjon som er oppført i skriptet er gyldige.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>Du aktiverte &quot;Opprett dekryptert innhold&quot; eller &quot;Pakk installerbart archive&quot;, men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Skriptnedlasting Mislyktes</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>Åpne NUS Skript</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>NUS Skript (*.nus *.json)</translation>
     </message>
@@ -503,8 +508,8 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av skriptfilen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
         <translation></translation>
     </message>
     <message>
@@ -512,27 +517,27 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av Tittel IDer!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>Tittelen ved indeks {script_data.index(title)} har ikke en Tittel ID!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>Tittelen ved indeks {index} har ikke en Tittel ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>Åpen Mappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Den angitte nedlastingsmappen finnes ikke!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Påfør patcher på IOS (gjelder kun WADer)</translation>
     </message>
@@ -550,12 +555,12 @@ Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypte
 Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>NUSGet Oppdatering Tilgjengelig</translation>
     </message>
@@ -564,7 +569,7 @@ Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&q
         <translation type="vanished">Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
@@ -573,7 +578,7 @@ Could not check for updates.</source>
 Kunne ikke sjekke for oppdateringer.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
@@ -582,7 +587,7 @@ There&apos;s a newer version of NUSGet available!</source>
 Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>

--- a/resources/translations/nusget_ro.ts
+++ b/resources/translations/nusget_ro.ts
@@ -68,6 +68,11 @@
         <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
         <translation>Română (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
+    <message>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="150"/>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -116,7 +121,7 @@ Titlurile marcate cu bifă sunt gratuite și au un tichet disponibil și pot fi 
 Titlurile vor fi descărcate într-un folder numit „NUSGet Downloads” în fișierul dvs. de download.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="232"/>
+        <location filename="../../NUSGet.py" line="242"/>
         <source>NUSGet Update Available</source>
         <translation>Actualizare NUSGet disponibilă</translation>
     </message>
@@ -138,88 +143,88 @@ Titlurile marcate cu bifă sunt libere și au un tichet valabil, ele pot fi decr
 Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads” în folderul dvs. de descărcări.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="163"/>
+        <location filename="../../NUSGet.py" line="173"/>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Folosiți Wii U NUS (mai rapid, afectează doar Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="233"/>
+        <location filename="../../NUSGet.py" line="243"/>
         <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
         <translation>&lt;b&gt;O nouă versiune de NUSGet este valabilă!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="334"/>
+        <location filename="../../NUSGet.py" line="344"/>
         <source>No Output Selected</source>
         <translation>Nu s-a selectat un output</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="335"/>
+        <location filename="../../NUSGet.py" line="345"/>
         <source>You have not selected any format to output the data in!</source>
         <translation>Nu ați selectat niciun format de ieșire!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="337"/>
+        <location filename="../../NUSGet.py" line="347"/>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Vă rugăm să selectați cel puțin o opțiune pentru modul în care doriți să salvați datele descărcate.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="349"/>
-        <location filename="../../NUSGet.py" line="553"/>
+        <location filename="../../NUSGet.py" line="359"/>
+        <location filename="../../NUSGet.py" line="565"/>
         <source>Invalid Download Directory</source>
         <translation>Director de descărcare invalid</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="350"/>
+        <location filename="../../NUSGet.py" line="360"/>
         <source>The specified download directory does not exist!</source>
         <translation>Directorul de descărcare specificat nu există!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="353"/>
+        <location filename="../../NUSGet.py" line="363"/>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
         <translation>Vă rugăm să vă asigurați că directorul de descărcare specificat există, și că aveți permisiuni pentru a-l accesa.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="383"/>
+        <location filename="../../NUSGet.py" line="393"/>
         <source>Invalid Title ID</source>
         <translation>Title ID invalid</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="384"/>
+        <location filename="../../NUSGet.py" line="394"/>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
         <translation>&lt;b&gt; Title ID pe care l-ați introdus nu este într-un format valid!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="389"/>
+        <location filename="../../NUSGet.py" line="399"/>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nu s-a găsit niciun titlu cu Title ID sau versiunea introdusă!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="394"/>
+        <location filename="../../NUSGet.py" line="404"/>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Decriptarea conținutului a eșuat! Nu s-a putut crea conținutul decriptat.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="401"/>
+        <location filename="../../NUSGet.py" line="411"/>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nu există tichet valabil pentru titlul cerut!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="417"/>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;S-a produs o eroare necunoscută!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="429"/>
+        <location filename="../../NUSGet.py" line="439"/>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Au apărut câteva probleme la rularea scriptului de descărcare.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="489"/>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;A apărut o eroare la procesarea fișierului script!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="489"/>
+        <location filename="../../NUSGet.py" line="500"/>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
         <translation>&lt;b&gt;A apărut o eroare la procesarea Title ID-urilor!&lt;/b&gt;</translation>
     </message>
@@ -228,12 +233,12 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">Title ID pe care l-ați introdus este invalid!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="386"/>
+        <location filename="../../NUSGet.py" line="396"/>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
         <translation>Title ID-urile trebuie să conțină exact 16 cifre și/sau litere. Vă rugăm introduceți un Title ID corect, sau selectați unul din meniul din stânga.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="388"/>
+        <location filename="../../NUSGet.py" line="398"/>
         <source>Title ID/Version Not Found</source>
         <translation>Title ID/Versiunea nu a fost găsită</translation>
     </message>
@@ -242,12 +247,12 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">Niciun titlu care să corespundă cu Title ID-ul sau cu versiunea introdusă nu a fost găsit!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="391"/>
+        <location filename="../../NUSGet.py" line="401"/>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
         <translation>Vă rugăm să vă asigurați că ați introdus un Title ID valid sau ați selectat unul din baza de date cu titluri, și că versiunea introdusă există pentru titlul pe care încercați să îl descărcați.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="393"/>
+        <location filename="../../NUSGet.py" line="403"/>
         <source>Content Decryption Failed</source>
         <translation>Decriptarea conținutului a eșuat</translation>
     </message>
@@ -256,12 +261,12 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">Decriptarea conținutului nu a reușit. Nu s-a putut crea conținutul decriptat.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="397"/>
+        <location filename="../../NUSGet.py" line="407"/>
         <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
         <translation>TMD-ul sau Ticket-ul dvs. sunt corupte, sau nu corespund cu conținutul de decriptat. Dacă ați bifat „Folosiți fișiere locale, dacă există”, încercați să debifați această opțiune înainte de a descărca din nou pentru a rezolva potențiale probleme cu datele existente  local.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="400"/>
+        <location filename="../../NUSGet.py" line="410"/>
         <source>Ticket Not Available</source>
         <translation>Ticket-ul nu este valabil</translation>
     </message>
@@ -270,12 +275,12 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">Niciun Ticket nu este valabil pentru titlul dorit!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="404"/>
+        <location filename="../../NUSGet.py" line="414"/>
         <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
         <translation>Nu se poate descărca un tichet pentru titlul cerut, dar ați selectat „Împachetați arhiva instalabilă” sau „Creați conținut decriptat”. Aceste opțiuni nu sunt valabile pentru titluri fărătichet. Doar conținuturile criptate au fost salvate.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="406"/>
+        <location filename="../../NUSGet.py" line="416"/>
         <source>Unknown Error</source>
         <translation>Eroare necunoscută</translation>
     </message>
@@ -284,12 +289,12 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">S-a produs o eroare necunoscută!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="409"/>
+        <location filename="../../NUSGet.py" line="419"/>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
         <translation>Vă rugăm încercați din nou. Dacă problema persistă, vă rugăm să deschideți un issue pe GitHub în care să explicați ce ați încercat să faceți atunci când această eroare a apărut.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="428"/>
+        <location filename="../../NUSGet.py" line="438"/>
         <source>Script Issues Occurred</source>
         <translation>Au apărut probleme cu scriptul</translation>
     </message>
@@ -298,32 +303,32 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">Au apărut câteva probleme la rularea scriptului descărcat.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="431"/>
+        <location filename="../../NUSGet.py" line="441"/>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Verificați logurile pentru mai multe detalii despre problemele întâmpinate.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="438"/>
+        <location filename="../../NUSGet.py" line="448"/>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
         <translation>Următoarele titluri nu au putut fi descărcate din cauza unei erori. Vă rugăm să vă asigurați că Title ID și versiunea listate în script sunt valide.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="448"/>
+        <location filename="../../NUSGet.py" line="458"/>
         <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
         <translation>Ați activat „Creare conținut decriptat” sau „Împachetați arhiva instalabilă”, dar următoarele titluri în script nu au tichete valabile.În acest caz, conținuturile encriptate au fost oricum descărcate.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="477"/>
         <source>Script Download Failed</source>
         <translation>Descărcarea scriptului a eșuat</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="468"/>
+        <location filename="../../NUSGet.py" line="478"/>
         <source>Open NUS Script</source>
         <translation>Deschideți script NUS</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="469"/>
+        <location filename="../../NUSGet.py" line="479"/>
         <source>NUS Scripts (*.nus *.json)</source>
         <translation>Scripturi NUS (*.nus *.json)</translation>
     </message>
@@ -332,31 +337,31 @@ Implicit, titlurile vor fi descărcate într-un folder numit „NUSGet Downloads
         <translation type="vanished">A apărut o eroare la parssarea acestui fișier script!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
-        <source>Error encountered at line {e.lineno}, column {e.colno}. Please double-check the script and try again.</source>
-        <translation>S-a produs o eroare la linia {e.lineno}, coloana {e.colno}. Vă rugăm verificați scriptul și încercați din nou.</translation>
+        <location filename="../../NUSGet.py" line="491"/>
+        <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
+        <translation>S-a produs o eroare la linia {lineno}, coloana {colno}. Vă rugăm verificați scriptul și încercați din nou.</translation>
     </message>
     <message>
         <source>An error occurred while parsing Title IDs!</source>
         <translation type="vanished">A apărut o eroare la procesarea Title ID-urilor!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="490"/>
-        <source>The title at index {script_data.index(title)} does not have a Title ID!</source>
-        <translation>Titlul la poziția {script_data.index(title)} nu are un Title ID!</translation>
+        <location filename="../../NUSGet.py" line="502"/>
+        <source>The title at index {index} does not have a Title ID!</source>
+        <translation>Titlul la poziția {index} nu are un Title ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="543"/>
+        <location filename="../../NUSGet.py" line="555"/>
         <source>Open Directory</source>
         <translation>Deschideți folder</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="566"/>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Directorul de descărcare specificat nu există!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="557"/>
+        <location filename="../../NUSGet.py" line="569"/>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
         <translation>Vă rugăm să vă asigurați că directorul de descărcare pe care vreți să il folosiți există, și că aveți permisiunea de a-l accesa.</translation>
     </message>
@@ -459,7 +464,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Despre NUSGet</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="157"/>
+        <location filename="../../NUSGet.py" line="167"/>
         <source>Pack installable archive (WAD/TAD)</source>
         <translation>Împachetați arhiva instalabilă (WAD/TAD)</translation>
     </message>
@@ -469,17 +474,17 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Nume fișier</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="159"/>
+        <location filename="../../NUSGet.py" line="169"/>
         <source>Keep encrypted contents</source>
         <translation>Păstrați conținuturile encriptate</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="161"/>
+        <location filename="../../NUSGet.py" line="171"/>
         <source>Create decrypted contents (*.app)</source>
         <translation>Creați conținuturi decriptate (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="162"/>
+        <location filename="../../NUSGet.py" line="172"/>
         <source>Use local files, if they exist</source>
         <translation>Folosiți fișiere locale, dacă există</translation>
     </message>
@@ -488,7 +493,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation type="vanished">Folosiți Wii U NUS (mai rapid, doar pentru Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="165"/>
+        <location filename="../../NUSGet.py" line="175"/>
         <source>Apply patches to IOS (Applies to WADs only)</source>
         <translation>Aplicați patch-uri pentru IOS (se aplică doar pentru WAD-uri)</translation>
     </message>
@@ -498,7 +503,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>vWII Setări titlu</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="166"/>
+        <location filename="../../NUSGet.py" line="176"/>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Re-encriptați titlul folosind cheia comună Wii</translation>
     </message>
@@ -508,12 +513,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Setări aplicație</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="167"/>
+        <location filename="../../NUSGet.py" line="177"/>
         <source>Check for updates on startup</source>
         <translation>Verificați dacă există actualizări la startup</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="168"/>
+        <location filename="../../NUSGet.py" line="178"/>
         <source>Use a custom download directory</source>
         <translation>Folosiți un director de descărcare propriu</translation>
     </message>
@@ -538,7 +543,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Cale de ieșire</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="60"/>
+        <location filename="../../modules/core.py" line="68"/>
         <source>
 
 Could not check for updates.</source>
@@ -547,7 +552,7 @@ Could not check for updates.</source>
 Nu s-a putut verifica dacă există actualizări.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="70"/>
+        <location filename="../../modules/core.py" line="78"/>
         <source>
 
 There&apos;s a newer version of NUSGet available!</source>
@@ -556,7 +561,7 @@ There&apos;s a newer version of NUSGet available!</source>
 O nouă versiune de NUSGet este valabilă!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="72"/>
+        <location filename="../../modules/core.py" line="80"/>
         <source>
 
 You&apos;re running the latest release of NUSGet.</source>


### PR DESCRIPTION
Other changes include:

* NUSGet.py: add translation file name fallback under Windows to fix a previously unhandled edge case (tested by me, provided by @NinjaCheetah himself).
* NUSGet.py: fix translation key lookups for strings that need to be formatted at runtime.

* ui_AboutDialog.py: fix translation key lookups for strings that need to be formatted at runtime.
* ui_AboutDialog.py: add myself to the list of translation contributors.

* Translations: update source and translation strings across all localization files to reflect the fixes mentioned above.
* Translations: update source string locations and add a new unfinished translation to all localization files (as a result of running update_translations.py).