### PR TITLE
Fixed various pretty bad translations for Norwegian

### DIFF
--- a/resources/translations/nusget_nb.ts
+++ b/resources/translations/nusget_nb.ts
@@ -83,7 +83,7 @@
     </message>
     <message>
         <source>Available Titles</source>
-        <translation type="vanished">Tilgjengelige Titler</translation>
+        <translation type="vanished">Tilgjengelige titler</translation>
     </message>
     <message>
         <location filename="../../qt/ui/MainMenu.ui" line="46"></location>
@@ -352,7 +352,7 @@ Titler er lastes ned til en mappe med navnet "NUSGet Downloads" i nedlastingsmap
     <message>
         <location filename="../../NUSGet.py" line="306"></location>
         <source>&lt;b&gt;There's a newer version of NUSGet available!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;En nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;En nyere versjon av NUSGet er tilgjengelig!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../../NUSGet.py" line="407"></location>

--- a/resources/translations/nusget_nb.ts
+++ b/resources/translations/nusget_nb.ts
@@ -4,80 +4,80 @@
 <context>
     <name>AboutNUSGet</name>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="16"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="16"></location>
         <source>About NUSGet</source>
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="33"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="33"></location>
         <source>NUSGet</source>
         <translation>NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="38"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="38"></location>
         <source>Version {nusget_version}</source>
         <translation>Versjon {nusget_version}</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="44"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="44"></location>
         <source>Using libWiiPy {libwiipy_version} &amp; libTWLPy {libtwlpy_version}</source>
         <translation>Bruker libWiiPy {libwiipy_version} &amp; libTWLPy {libtwlpy_version}</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="49"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="49"></location>
         <source>© 2024-2025 NinjaCheetah &amp; Contributors</source>
         <translation>© 2024-2025 NinjaCheetah &amp; Contributors</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="65"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="65"></location>
         <source>View Project on GitHub</source>
-        <translation>Se Prosjektet på GitHub</translation>
+        <translation>Se prosjektet på GitHub</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="81"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="81"></location>
         <source>Translations</source>
         <translation>Oversettelser</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="89"/>
-        <source>French (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Fransk (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="89"></location>
+        <source>French (Français): &lt;a href=https://github.com/rougets style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Fransk (Français): &lt;a href=https://github.com/rougets style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="91"/>
-        <source>German (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Tysk (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="91"></location>
+        <source>German (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Tysk (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="93"/>
-        <source>Italian (Italiano): &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Italiensk (Italiano): &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="93"></location>
+        <source>Italian (Italiano): &lt;a href=https://github.com/LNLenost style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Italiensk (Italiano): &lt;a href=https://github.com/LNLenost style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="95"/>
-        <source>Korean (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Koreansk (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="95"></location>
+        <source>Korean (한국어): &lt;a href=https://github.com/DDinghoya style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Koreansk (한국어): &lt;a href=https://github.com/DDinghoya style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="97"/>
-        <source>Norwegian (Norsk): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Norsk (Bokmål): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="97"></location>
+        <source>Norwegian (Norsk): &lt;a href=https://github.com/rolfiee style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Norsk (Bokmål): &lt;a href=https://github.com/dandelionsprout style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;Imre Eilertsen&lt;/b&gt;&lt;/a&gt;, &lt;a href=https://github.com/rolfiee style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="99"/>
-        <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="99"></location>
+        <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="101"/>
-        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Spansk (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="101"></location>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Spansk (Español): &lt;a href=https://github.com/DarkMatterCore style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="26"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="26"></location>
         <source>MainWindow</source>
         <translation>MainWindow</translation>
     </message>
@@ -86,123 +86,123 @@
         <translation type="vanished">Tilgjengelige Titler</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="46"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="46"></location>
         <source>Search</source>
         <translation>Søk</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="59"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="59"></location>
         <source>Clear</source>
         <translation>Klar</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="90"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="90"></location>
         <source>Wii</source>
         <translation>Wii</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="100"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="100"></location>
         <source>vWii</source>
         <translation>vWii</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="110"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="110"></location>
         <source>DSi</source>
         <translation>DSi</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="135"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="135"></location>
         <source>Title ID</source>
-        <translation>Tittel ID</translation>
+        <translation>Tittel-ID</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="142"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="142"></location>
         <source>v</source>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="155"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="155"></location>
         <source>Version</source>
         <translation>Versjon</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="162"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="162"></location>
         <source>Console:</source>
         <translation>Konsoll:</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="198"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="198"></location>
         <source>Start Download</source>
-        <translation>Start Nedlasting</translation>
+        <translation>Start nedlasting</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="211"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="211"></location>
         <source>Run Script</source>
-        <translation>Kjøre Skript</translation>
+        <translation>Kjør skript</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="238"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="238"></location>
         <source>General Settings</source>
-        <translation>Generelle Instillinger</translation>
+        <translation>Generelle innstillinger</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="485"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="485"></location>
         <source>Options</source>
-        <translation>Instillinger</translation>
+        <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="489"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="489"></location>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="503"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="503"></location>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="520"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="520"></location>
         <source>About NUSGet</source>
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="545"/>
-        <location filename="../../qt/ui/MainMenu.ui" line="617"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="545"></location>
+        <location filename="../../qt/ui/MainMenu.ui" line="617"></location>
         <source>System (Default)</source>
         <translation>System (Standard)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="625"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="625"></location>
         <source>Light</source>
         <translation>Lys</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="633"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="633"></location>
         <source>Dark</source>
         <translation>Mørk</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="218"/>
+        <location filename="../../NUSGet.py" line="218"></location>
         <source>Pack installable archive (WAD/TAD)</source>
-        <translation>Pakke installerbart arkiv (WAD/TAD)</translation>
+        <translation>Pakk installerbart arkiv (WAD/TAD)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="251"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="251"></location>
         <source>File Name</source>
         <translation>Filnavn</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="220"/>
+        <location filename="../../NUSGet.py" line="220"></location>
         <source>Keep encrypted contents</source>
         <translation>Oppbevar kryptert innhold</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="222"/>
+        <location filename="../../NUSGet.py" line="222"></location>
         <source>Create decrypted contents (*.app)</source>
-        <translation>Opprette dekryptert innold (*.app)</translation>
+        <translation>Opprett dekryptert innhold (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="223"/>
+        <location filename="../../NUSGet.py" line="223"></location>
         <source>Use local files, if they exist</source>
         <translation>Bruk lokale filer, hvis de finnes</translation>
     </message>
@@ -211,99 +211,99 @@
         <translation type="vanished">Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="324"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="324"></location>
         <source>vWii Title Settings</source>
-        <translation>vWii Tittelinstillinger</translation>
+        <translation>vWii-tittelinnstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="227"/>
+        <location filename="../../NUSGet.py" line="227"></location>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Krypter tittelen på nytt ved hjelp av Wii Common Key</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="343"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="343"></location>
         <source>App Settings</source>
-        <translation>Appinstillinger</translation>
+        <translation>Appinnstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="228"/>
+        <location filename="../../NUSGet.py" line="228"></location>
         <source>Check for updates on startup</source>
         <translation>Sjekk for oppdateringer ved oppstart</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="229"/>
+        <location filename="../../NUSGet.py" line="229"></location>
         <source>Use a custom download directory</source>
-        <translation>Bruke en egendefinert nedlastingsmappe</translation>
+        <translation>Bruk en selvvalgt nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="378"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="378"></location>
         <source>Select...</source>
         <translation>Velg...</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="432"/>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <location filename="../../qt/ui/MainMenu.ui" line="432"></location>
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.AppleSystemUIFont&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.AppleSystemUIFont&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="477"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="477"></location>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="531"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="531"></location>
         <source>About Qt</source>
         <translation>Om Qt</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="368"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="368"></location>
         <source>Output Path</source>
         <translatorcomment>Utgangsbane</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>NUSGet v{nusget_version}
@@ -315,7 +315,7 @@ Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-Titles will be downloaded to a folder named &quot;NUSGet&quot; inside your downloads folder.</source>
+Titles will be downloaded to a folder named "NUSGet" inside your downloads folder.</source>
         <translation type="vanished">NUSGet v{nusget_version}
 Utviklet av NinjaCheetah
 Drevet av libWiiPy {libwiipy_version}
@@ -325,7 +325,7 @@ Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begyn
 
 Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
 
-Titler er lastes ned til en mappe med navnet &quot;NUSGet&quot; i nedlastingsmappen din.</translation>
+Titler er lastes ned til en mappe med navnet "NUSGet" i nedlastingsmappen din.</translation>
     </message>
     <message>
         <source>NUSGet v{nusget_version}
@@ -337,7 +337,7 @@ Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-Titles will be downloaded to a folder named &quot;NUSGet Downloads&quot; inside your downloads folder.</source>
+Titles will be downloaded to a folder named "NUSGet Downloads" inside your downloads folder.</source>
         <translation type="vanished">NUSGet v{nusget_version}
 Utviklet av NinjaCheetah
 Drevet av libWiiPy {libwiipy_version}
@@ -347,102 +347,102 @@ Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begyn
 
 Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
 
-Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
+Titler er lastes ned til en mappe med navnet "NUSGet Downloads" i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="306"/>
-        <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Det finnes en nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
+        <location filename="../../NUSGet.py" line="306"></location>
+        <source>&lt;b&gt;There's a newer version of NUSGet available!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;En nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="407"></location>
         <source>No Output Selected</source>
-        <translation>Ingen Utgang Valgt</translation>
+        <translation>Ingen utdata valgt</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="408"/>
+        <location filename="../../NUSGet.py" line="408"></location>
         <source>You have not selected any format to output the data in!</source>
-        <translation>Du ikke har valgt noe format å lagre dataene i!</translation>
+        <translation>Du har ikke valgt noe format å lagre dataene i!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="410"/>
+        <location filename="../../NUSGet.py" line="410"></location>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Velg minst ett valg for hvordan du vil at nedlastingen skal lagres.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="422"/>
-        <location filename="../../NUSGet.py" line="628"/>
+        <location filename="../../NUSGet.py" line="422"></location>
+        <location filename="../../NUSGet.py" line="628"></location>
         <source>Invalid Download Directory</source>
-        <translation>Ugyldig Nedlastingsmappe</translation>
+        <translation>Ugyldig nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="423"/>
+        <location filename="../../NUSGet.py" line="423"></location>
         <source>The specified download directory does not exist!</source>
         <translation>Den angitte nedlastingsmappen finnes ikke!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="426"/>
+        <location filename="../../NUSGet.py" line="426"></location>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
-        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
+        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse til å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="456"/>
+        <location filename="../../NUSGet.py" line="456"></location>
         <source>Invalid Title ID</source>
-        <translation>Ugyldig Tittel ID</translation>
+        <translation>Ugyldig tittel-ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="457"/>
+        <location filename="../../NUSGet.py" line="457"></location>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Tittel IDen du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Tittel-ID-en du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="462"/>
+        <location filename="../../NUSGet.py" line="462"></location>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Ingen tittel med oppgitt tittel-ID eller -versjon ble funnet!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="467"></location>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Dekryptering av innholdet mislyktes! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="474"/>
+        <location filename="../../NUSGet.py" line="474"></location>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen billett er tilgjengelig for den forespurte tittelen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
+        <location filename="../../NUSGet.py" line="480"></location>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;En ukjent feil har oppstått!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="502"/>
+        <location filename="../../NUSGet.py" line="502"></location>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Noen feil oppstod under kjøring av nedlastingsskriptet.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="552"/>
+        <location filename="../../NUSGet.py" line="552"></location>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av skriptfilen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="563"/>
+        <location filename="../../NUSGet.py" line="563"></location>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Det oppstod en feil under parsing av Tittel IDer!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Det oppstod en feil under parsing av tittel-ID-er!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="661"/>
-        <location filename="../../NUSGet.py" line="671"/>
+        <location filename="../../NUSGet.py" line="661"></location>
+        <location filename="../../NUSGet.py" line="671"></location>
         <source>Restart Required</source>
-        <translation>Omstart Nødvendig</translation>
+        <translation>Omstart kreves</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="662"/>
+        <location filename="../../NUSGet.py" line="662"></location>
         <source>NUSGet must be restarted for the selected language to take effect.</source>
         <translation>NUSGet må startes på nytt for at det valgte språket skal tre i kraft.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="672"/>
+        <location filename="../../NUSGet.py" line="672"></location>
         <source>NUSGet must be restarted for the selected theme to take effect.</source>
         <translation>NUSGet må startes på nytt for at det valgte temaet skal tre i kraft.</translation>
     </message>
@@ -451,111 +451,111 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Tittel IDen du har angitt er ikke i et gyldig format!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="459"/>
+        <location filename="../../NUSGet.py" line="459"></location>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
-        <translation>Tittel IDer må være 16-sifrede tall og bokstav strenger. Vennligst skriv inn en korrekt formatert Tittel ID, eller velg en fra menyen til venstre.</translation>
+        <translation>Tittel-ID-er må være 16-sifrede strenger med tall og bokstaver. Vennligst skriv inn en korrekt formatert tittel-ID, eller velg en fra menyen til venstre.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="461"/>
+        <location filename="../../NUSGet.py" line="461"></location>
         <source>Title ID/Version Not Found</source>
-        <translation>Tittel ID/Versjon Ikke Funnet</translation>
+        <translation>Tittel-ID/-versjon ble ikke funnet</translation>
     </message>
     <message>
         <source>No title with the provided Title ID or version could be found!</source>
         <translation type="vanished">Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="464"/>
+        <location filename="../../NUSGet.py" line="464"></location>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
-        <translation>Sjekk at du har oppgitt en gyldig Tittel ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
+        <translation>Sjekk at du har oppgitt en gyldig tittel-ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="466"/>
+        <location filename="../../NUSGet.py" line="466"></location>
         <source>Content Decryption Failed</source>
-        <translation>Dekryptering av Innhold Mislyktes</translation>
+        <translation>Dekryptering av innhold mislyktes</translation>
     </message>
     <message>
         <source>Content decryption was not successful! Decrypted contents could not be created.</source>
         <translation type="vanished">Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="470"/>
-        <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
-        <translation>TMDen eller Billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet some dekrypteres. Hvis du har krysset av for &quot;Bruk lokale filer, hvis de finnes&quot;, kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
+        <location filename="../../NUSGet.py" line="470"></location>
+        <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked "Use local files, if they exist", try disabling that option before trying the download again to fix potential issues with local data.</source>
+        <translation>TMD-en eller billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet som dekrypteres. Hvis du har krysset av for "Bruk lokale filer, hvis de finnes", kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="473"/>
+        <location filename="../../NUSGet.py" line="473"></location>
         <source>Ticket Not Available</source>
-        <translation>Billett Ikke Tilgjengelig</translation>
+        <translation>Billett ikke tilgjengelig</translation>
     </message>
     <message>
         <source>No Ticket is Available for the Requested Title!</source>
         <translation type="vanished">Ingen billett er tilgjengelig for den forespurte tittelen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="477"/>
-        <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
-        <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt &quot;Pakk installerbart arkiv&quot; eller &quot;Opprett dekryptert innhold&quot;. Disse alternativene er ikke tilgjenelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
+        <location filename="../../NUSGet.py" line="477"></location>
+        <source>A ticket could not be downloaded for the requested title, but you have selected "Pack installable archive" or "Create decrypted contents". These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
+        <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt "Pakk installerbart arkiv" eller "Opprett dekryptert innhold". Disse alternativene er ikke tilgjengelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="479"></location>
         <source>Unknown Error</source>
-        <translation>Ukjent Feil</translation>
+        <translation>Ukjent feil</translation>
     </message>
     <message>
         <source>An Unknown Error has Occurred!</source>
         <translation type="vanished">En ukjent feil har oppstått!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="482"/>
+        <location filename="../../NUSGet.py" line="482"></location>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
-        <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne et nytt issue på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
+        <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne en ny saksrapport på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="501"/>
+        <location filename="../../NUSGet.py" line="501"></location>
         <source>Script Issues Occurred</source>
-        <translation>Skriptfeil Oppstod</translation>
+        <translation>Skriptfeil oppstod</translation>
     </message>
     <message>
         <source>Some issues occurred while running the download script.</source>
         <translation type="vanished">Noen feil oppstod under kjøring av nedlastingsskriptet.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="504"/>
+        <location filename="../../NUSGet.py" line="504"></location>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Sjekk loggen for mer informasjon om feilene som har oppstått.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="511"/>
+        <location filename="../../NUSGet.py" line="511"></location>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
-        <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at Tittel IDen og versjon som er oppført i skriptet er gyldige.</translation>
+        <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at tittel-ID-en og -versjonen som er oppført i skriptet er gyldige.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="521"/>
-        <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
-        <translation>Du aktiverte &quot;Opprett dekryptert innhold&quot; eller &quot;Pakk installerbart archive&quot;, men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
+        <location filename="../../NUSGet.py" line="521"></location>
+        <source>You enabled "Create decrypted contents" or "Pack installable archive", but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
+        <translation>Du skrudde på "Opprett dekryptert innhold" eller "Pakk installerbart arkiv", men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="540"/>
+        <location filename="../../NUSGet.py" line="540"></location>
         <source>Script Download Failed</source>
-        <translation>Skriptnedlasting Mislyktes</translation>
+        <translation>Skriptnedlasting mislyktes</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="541"/>
+        <location filename="../../NUSGet.py" line="541"></location>
         <source>Open NUS Script</source>
-        <translation>Åpne NUS Skript</translation>
+        <translation>Åpne NUS-skript</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="542"/>
+        <location filename="../../NUSGet.py" line="542"></location>
         <source>NUS Scripts (*.nus *.json)</source>
-        <translation>NUS Skript (*.nus *.json)</translation>
+        <translation>NUS-skript (*.nus *.json)</translation>
     </message>
     <message>
         <source>An error occurred while parsing the script file!</source>
         <translation type="vanished">Det oppstod en feil under parsing av skriptfilen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="554"></location>
         <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
         <translation></translation>
     </message>
@@ -564,59 +564,59 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av Tittel IDer!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="565"/>
+        <location filename="../../NUSGet.py" line="565"></location>
         <source>The title at index {index} does not have a Title ID!</source>
-        <translation>Tittelen ved indeks {index} har ikke en Tittel ID!</translation>
+        <translation>Tittelen ved indeks {index} har ikke en tittel-ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="618"/>
+        <location filename="../../NUSGet.py" line="618"></location>
         <source>Open Directory</source>
-        <translation>Åpen Mappe</translation>
+        <translation>Åpne mappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="629"/>
+        <location filename="../../NUSGet.py" line="629"></location>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Den angitte nedlastingsmappen finnes ikke!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="632"/>
+        <location filename="../../NUSGet.py" line="632"></location>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
-        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
+        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse til å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="226"/>
+        <location filename="../../NUSGet.py" line="226"></location>
         <source>Apply patches to IOS (Applies to WADs only)</source>
-        <translation>Påfør patcher på IOS (gjelder kun WADer)</translation>
+        <translation>Benytt patcher på IOS (gjelder kun WAD-er)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="119"/>
+        <location filename="../../NUSGet.py" line="119"></location>
         <source>Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&quot; inside your downloads folder.</source>
-        <translation>Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begynne.
+By default, titles will be downloaded to a folder named "NUSGet Downloads" inside your downloads folder.</source>
+        <translation>Velg en tittel fra listen til venstre, eller skriv inn en tittel-ID for å begynne.
 
-Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
+Titler merket med en hake er gratis og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X har ikke en billett, og bare det krypterte innholdet kan lagres.
 
-Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
+Som standard, lastes titler ned til en mappe med navnet "NUSGet Downloads" i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="224"/>
+        <location filename="../../NUSGet.py" line="224"></location>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="305"/>
+        <location filename="../../NUSGet.py" line="305"></location>
         <source>NUSGet Update Available</source>
-        <translation>NUSGet Oppdatering Tilgjengelig</translation>
+        <translation>NUSGet-oppdatering tilgjengelig</translation>
     </message>
     <message>
-        <source>There&apos;s a newer version of NUSGet available!</source>
+        <source>There's a newer version of NUSGet available!</source>
         <translation type="vanished">Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="74"/>
+        <location filename="../../modules/core.py" line="74"></location>
         <source>
 
 Could not check for updates.</source>
@@ -625,19 +625,19 @@ Could not check for updates.</source>
 Kunne ikke sjekke for oppdateringer.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="84"/>
+        <location filename="../../modules/core.py" line="84"></location>
         <source>
 
-There&apos;s a newer version of NUSGet available!</source>
+There's a newer version of NUSGet available!</source>
         <translation>
 
-Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
+En nyere versjon av NUSGet er tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="86"/>
+        <location filename="../../modules/core.py" line="86"></location>
         <source>
 
-You&apos;re running the latest release of NUSGet.</source>
+You're running the latest release of NUSGet.</source>
         <translation>
 
 Du kjører den nyeste versjonen av NUSGet.</translation>

--- a/resources/translations/nusget_no.ts
+++ b/resources/translations/nusget_no.ts
@@ -4,80 +4,80 @@
 <context>
     <name>AboutNUSGet</name>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="16"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="16"></location>
         <source>About NUSGet</source>
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="33"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="33"></location>
         <source>NUSGet</source>
         <translation>NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="38"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="38"></location>
         <source>Version {nusget_version}</source>
         <translation>Versjon {nusget_version}</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="44"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="44"></location>
         <source>Using libWiiPy {libwiipy_version} &amp; libTWLPy {libtwlpy_version}</source>
         <translation>Bruker libWiiPy {libwiipy_version} &amp; libTWLPy {libtwlpy_version}</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="49"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="49"></location>
         <source>© 2024-2025 NinjaCheetah &amp; Contributors</source>
         <translation>© 2024-2025 NinjaCheetah &amp; Contributors</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="65"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="65"></location>
         <source>View Project on GitHub</source>
-        <translation>Se Prosjektet på GitHub</translation>
+        <translation>Se prosjektet på GitHub</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="81"/>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="81"></location>
         <source>Translations</source>
         <translation>Oversettelser</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="89"/>
-        <source>French (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Fransk (Français): &lt;a href=https://github.com/rougets style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="89"></location>
+        <source>French (Français): &lt;a href=https://github.com/rougets style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Fransk (Français): &lt;a href=https://github.com/rougets style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rougets&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="91"/>
-        <source>German (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Tysk (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="91"></location>
+        <source>German (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Tysk (Deutsch): &lt;a href=https://github.com/yeah-its-gloria style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;yeah-its-gloria&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="93"/>
-        <source>Italian (Italiano): &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Italiensk (Italiano): &lt;a href=https://github.com/LNLenost style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="93"></location>
+        <source>Italian (Italiano): &lt;a href=https://github.com/LNLenost style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Italiensk (Italiano): &lt;a href=https://github.com/LNLenost style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;LNLenost&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="95"/>
-        <source>Korean (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Koreansk (한국어): &lt;a href=https://github.com/DDinghoya style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="95"></location>
+        <source>Korean (한국어): &lt;a href=https://github.com/DDinghoya style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Koreansk (한국어): &lt;a href=https://github.com/DDinghoya style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DDinghoya&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="97"/>
-        <source>Norwegian (Norsk): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Norsk (Bokmål): &lt;a href=https://github.com/rolfiee style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="97"></location>
+        <source>Norwegian (Norsk): &lt;a href=https://github.com/rolfiee style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Norsk (Bokmål): &lt;a href=https://github.com/dandelionsprout style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;Imre Eilertsen&lt;/b&gt;&lt;/a&gt;, &lt;a href=https://github.com/rolfiee style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;rolfiee&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="99"/>
-        <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="99"></location>
+        <source>Romanian (Română): &lt;a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Rumensk (Română): &lt;a href=https://github.com/NotImplementedLife style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;NotImplementedLife&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/py/ui_AboutDialog.py" line="101"/>
-        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
-        <translation>Spansk (Español): &lt;a href=https://github.com/DarkMatterCore style=&apos;color: #4a86e8; text-decoration: none;&apos;&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</translation>
+        <location filename="../../qt/py/ui_AboutDialog.py" line="101"></location>
+        <source>Spanish (Español): &lt;a href=https://github.com/DarkMatterCore style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</source>
+        <translation>Spansk (Español): &lt;a href=https://github.com/DarkMatterCore style='color: #4a86e8; text-decoration: none;'&gt;&lt;b&gt;DarkMatterCore&lt;/b&gt;&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="26"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="26"></location>
         <source>MainWindow</source>
         <translation>MainWindow</translation>
     </message>
@@ -86,123 +86,123 @@
         <translation type="vanished">Tilgjengelige Titler</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="46"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="46"></location>
         <source>Search</source>
         <translation>Søk</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="59"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="59"></location>
         <source>Clear</source>
         <translation>Klar</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="90"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="90"></location>
         <source>Wii</source>
         <translation>Wii</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="100"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="100"></location>
         <source>vWii</source>
         <translation>vWii</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="110"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="110"></location>
         <source>DSi</source>
         <translation>DSi</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="135"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="135"></location>
         <source>Title ID</source>
-        <translation>Tittel ID</translation>
+        <translation>Tittel-ID</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="142"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="142"></location>
         <source>v</source>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="155"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="155"></location>
         <source>Version</source>
         <translation>Versjon</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="162"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="162"></location>
         <source>Console:</source>
         <translation>Konsoll:</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="198"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="198"></location>
         <source>Start Download</source>
-        <translation>Start Nedlasting</translation>
+        <translation>Start nedlasting</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="211"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="211"></location>
         <source>Run Script</source>
-        <translation>Kjøre Skript</translation>
+        <translation>Kjør skript</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="238"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="238"></location>
         <source>General Settings</source>
-        <translation>Generelle Instillinger</translation>
+        <translation>Generelle innstillinger</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="485"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="485"></location>
         <source>Options</source>
-        <translation>Instillinger</translation>
+        <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="489"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="489"></location>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="503"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="503"></location>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="520"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="520"></location>
         <source>About NUSGet</source>
         <translation>Om NUSGet</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="545"/>
-        <location filename="../../qt/ui/MainMenu.ui" line="617"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="545"></location>
+        <location filename="../../qt/ui/MainMenu.ui" line="617"></location>
         <source>System (Default)</source>
         <translation>System (Standard)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="625"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="625"></location>
         <source>Light</source>
         <translation>Lys</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="633"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="633"></location>
         <source>Dark</source>
         <translation>Mørk</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="218"/>
+        <location filename="../../NUSGet.py" line="218"></location>
         <source>Pack installable archive (WAD/TAD)</source>
-        <translation>Pakke installerbart arkiv (WAD/TAD)</translation>
+        <translation>Pakk installerbart arkiv (WAD/TAD)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="251"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="251"></location>
         <source>File Name</source>
         <translation>Filnavn</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="220"/>
+        <location filename="../../NUSGet.py" line="220"></location>
         <source>Keep encrypted contents</source>
         <translation>Oppbevar kryptert innhold</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="222"/>
+        <location filename="../../NUSGet.py" line="222"></location>
         <source>Create decrypted contents (*.app)</source>
-        <translation>Opprette dekryptert innold (*.app)</translation>
+        <translation>Opprett dekryptert innhold (*.app)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="223"/>
+        <location filename="../../NUSGet.py" line="223"></location>
         <source>Use local files, if they exist</source>
         <translation>Bruk lokale filer, hvis de finnes</translation>
     </message>
@@ -211,99 +211,99 @@
         <translation type="vanished">Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="324"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="324"></location>
         <source>vWii Title Settings</source>
-        <translation>vWii Tittelinstillinger</translation>
+        <translation>vWii-tittelinnstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="227"/>
+        <location filename="../../NUSGet.py" line="227"></location>
         <source>Re-encrypt title using the Wii Common Key</source>
         <translation>Krypter tittelen på nytt ved hjelp av Wii Common Key</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="343"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="343"></location>
         <source>App Settings</source>
-        <translation>Appinstillinger</translation>
+        <translation>Appinnstillinger</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="228"/>
+        <location filename="../../NUSGet.py" line="228"></location>
         <source>Check for updates on startup</source>
         <translation>Sjekk for oppdateringer ved oppstart</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="229"/>
+        <location filename="../../NUSGet.py" line="229"></location>
         <source>Use a custom download directory</source>
-        <translation>Bruke en egendefinert nedlastingsmappe</translation>
+        <translation>Bruk en selvvalgt nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="378"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="378"></location>
         <source>Select...</source>
         <translation>Velg...</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="432"/>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <location filename="../../qt/ui/MainMenu.ui" line="432"></location>
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.AppleSystemUIFont&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.AppleSystemUIFont&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="477"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="477"></location>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="531"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="531"></location>
         <source>About Qt</source>
         <translation>Om Qt</translation>
     </message>
     <message>
-        <location filename="../../qt/ui/MainMenu.ui" line="368"/>
+        <location filename="../../qt/ui/MainMenu.ui" line="368"></location>
         <source>Output Path</source>
         <translatorcomment>Utgangsbane</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;meta charset="utf-8" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
 hr { height: 1px; border-width: 0; }
-li.unchecked::marker { content: &quot;\2610&quot;; }
-li.checked::marker { content: &quot;\2612&quot;; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+li.unchecked::marker { content: "\2610"; }
+li.checked::marker { content: "\2612"; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Sans Serif&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>NUSGet v{nusget_version}
@@ -315,7 +315,7 @@ Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-Titles will be downloaded to a folder named &quot;NUSGet&quot; inside your downloads folder.</source>
+Titles will be downloaded to a folder named "NUSGet" inside your downloads folder.</source>
         <translation type="vanished">NUSGet v{nusget_version}
 Utviklet av NinjaCheetah
 Drevet av libWiiPy {libwiipy_version}
@@ -325,7 +325,7 @@ Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begyn
 
 Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
 
-Titler er lastes ned til en mappe med navnet &quot;NUSGet&quot; i nedlastingsmappen din.</translation>
+Titler er lastes ned til en mappe med navnet "NUSGet" i nedlastingsmappen din.</translation>
     </message>
     <message>
         <source>NUSGet v{nusget_version}
@@ -337,7 +337,7 @@ Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-Titles will be downloaded to a folder named &quot;NUSGet Downloads&quot; inside your downloads folder.</source>
+Titles will be downloaded to a folder named "NUSGet Downloads" inside your downloads folder.</source>
         <translation type="vanished">NUSGet v{nusget_version}
 Utviklet av NinjaCheetah
 Drevet av libWiiPy {libwiipy_version}
@@ -347,102 +347,102 @@ Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begyn
 
 Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
 
-Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
+Titler er lastes ned til en mappe med navnet "NUSGet Downloads" i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="306"/>
-        <source>&lt;b&gt;There&apos;s a newer version of NUSGet available!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Det finnes en nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
+        <location filename="../../NUSGet.py" line="306"></location>
+        <source>&lt;b&gt;There's a newer version of NUSGet available!&lt;/b&gt;</source>
+        <translation>&lt;b&gt;En nyere versjon av NUSGet tilgjengelig!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="407"/>
+        <location filename="../../NUSGet.py" line="407"></location>
         <source>No Output Selected</source>
-        <translation>Ingen Utgang Valgt</translation>
+        <translation>Ingen utdata valgt</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="408"/>
+        <location filename="../../NUSGet.py" line="408"></location>
         <source>You have not selected any format to output the data in!</source>
-        <translation>Du ikke har valgt noe format å lagre dataene i!</translation>
+        <translation>Du har ikke valgt noe format å lagre dataene i!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="410"/>
+        <location filename="../../NUSGet.py" line="410"></location>
         <source>Please select at least one option for how you would like the download to be saved.</source>
         <translation>Velg minst ett valg for hvordan du vil at nedlastingen skal lagres.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="422"/>
-        <location filename="../../NUSGet.py" line="628"/>
+        <location filename="../../NUSGet.py" line="422"></location>
+        <location filename="../../NUSGet.py" line="628"></location>
         <source>Invalid Download Directory</source>
-        <translation>Ugyldig Nedlastingsmappe</translation>
+        <translation>Ugyldig nedlastingsmappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="423"/>
+        <location filename="../../NUSGet.py" line="423"></location>
         <source>The specified download directory does not exist!</source>
         <translation>Den angitte nedlastingsmappen finnes ikke!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="426"/>
+        <location filename="../../NUSGet.py" line="426"></location>
         <source>Please make sure the specified download directory exists, and that you have permission to access it.</source>
-        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
+        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse til å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="456"/>
+        <location filename="../../NUSGet.py" line="456"></location>
         <source>Invalid Title ID</source>
-        <translation>Ugyldig Tittel ID</translation>
+        <translation>Ugyldig tittel-ID</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="457"/>
+        <location filename="../../NUSGet.py" line="457"></location>
         <source>&lt;b&gt;The Title ID you have entered is not in a valid format!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Tittel IDen du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Tittel-ID-en du har angitt er ikke i et gyldig format!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="462"/>
+        <location filename="../../NUSGet.py" line="462"></location>
         <source>&lt;b&gt;No title with the provided Title ID or version could be found!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Ingen tittel med oppgitt tittel-ID eller -versjon ble funnet!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="467"/>
+        <location filename="../../NUSGet.py" line="467"></location>
         <source>&lt;b&gt;Content decryption was not successful! Decrypted contents could not be created.&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Dekryptering av innholdet mislyktes! Dekryptert innhold kunne ikke opprettes.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="474"/>
+        <location filename="../../NUSGet.py" line="474"></location>
         <source>&lt;b&gt;No Ticket is Available for the Requested Title!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ingen billett er tilgjengelig for den forespurte tittelen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="480"/>
+        <location filename="../../NUSGet.py" line="480"></location>
         <source>&lt;b&gt;An Unknown Error has Occurred!&lt;/b&gt;</source>
         <translation>&lt;b&gt;En ukjent feil har oppstått!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="502"/>
+        <location filename="../../NUSGet.py" line="502"></location>
         <source>&lt;b&gt;Some issues occurred while running the download script.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Noen feil oppstod under kjøring av nedlastingsskriptet.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="552"/>
+        <location filename="../../NUSGet.py" line="552"></location>
         <source>&lt;b&gt;An error occurred while parsing the script file!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Det oppstod en feil under parsing av skriptfilen!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="563"/>
+        <location filename="../../NUSGet.py" line="563"></location>
         <source>&lt;b&gt;An error occurred while parsing Title IDs!&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Det oppstod en feil under parsing av Tittel IDer!&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Det oppstod en feil under parsing av tittel-ID-er!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="661"/>
-        <location filename="../../NUSGet.py" line="671"/>
+        <location filename="../../NUSGet.py" line="661"></location>
+        <location filename="../../NUSGet.py" line="671"></location>
         <source>Restart Required</source>
-        <translation>Omstart Nødvendig</translation>
+        <translation>Omstart kreves</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="662"/>
+        <location filename="../../NUSGet.py" line="662"></location>
         <source>NUSGet must be restarted for the selected language to take effect.</source>
         <translation>NUSGet må startes på nytt for at det valgte språket skal tre i kraft.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="672"/>
+        <location filename="../../NUSGet.py" line="672"></location>
         <source>NUSGet must be restarted for the selected theme to take effect.</source>
         <translation>NUSGet må startes på nytt for at det valgte temaet skal tre i kraft.</translation>
     </message>
@@ -451,111 +451,111 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Tittel IDen du har angitt er ikke i et gyldig format!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="459"/>
+        <location filename="../../NUSGet.py" line="459"></location>
         <source>Title IDs must be 16 digit strings of numbers and letters. Please enter a correctly formatted Title ID, or select one from the menu on the left.</source>
-        <translation>Tittel IDer må være 16-sifrede tall og bokstav strenger. Vennligst skriv inn en korrekt formatert Tittel ID, eller velg en fra menyen til venstre.</translation>
+        <translation>Tittel-ID-er må være 16-sifrede strenger med tall og bokstaver. Vennligst skriv inn en korrekt formatert tittel-ID, eller velg en fra menyen til venstre.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="461"/>
+        <location filename="../../NUSGet.py" line="461"></location>
         <source>Title ID/Version Not Found</source>
-        <translation>Tittel ID/Versjon Ikke Funnet</translation>
+        <translation>Tittel-ID/-versjon ble ikke funnet</translation>
     </message>
     <message>
         <source>No title with the provided Title ID or version could be found!</source>
         <translation type="vanished">Ingen tittel med oppgitt Tittel ID eller versjon ble funnet!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="464"/>
+        <location filename="../../NUSGet.py" line="464"></location>
         <source>Please make sure that you have entered a valid Title ID, or selected one from the title database, and that the provided version exists for the title you are attempting to download.</source>
-        <translation>Sjekk at du har oppgitt en gyldig Tittel ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
+        <translation>Sjekk at du har oppgitt en gyldig tittel-ID, eller valgt en fra titteldatabasen, og at den angitte versjonen finnes for tittelen du forsøker å laste ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="466"/>
+        <location filename="../../NUSGet.py" line="466"></location>
         <source>Content Decryption Failed</source>
-        <translation>Dekryptering av Innhold Mislyktes</translation>
+        <translation>Dekryptering av innhold mislyktes</translation>
     </message>
     <message>
         <source>Content decryption was not successful! Decrypted contents could not be created.</source>
         <translation type="vanished">Dekryptering av innhold var ikke vellykket! Dekryptert innhold kunne ikke opprettes.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="470"/>
-        <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked &quot;Use local files, if they exist&quot;, try disabling that option before trying the download again to fix potential issues with local data.</source>
-        <translation>TMDen eller Billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet some dekrypteres. Hvis du har krysset av for &quot;Bruk lokale filer, hvis de finnes&quot;, kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
+        <location filename="../../NUSGet.py" line="470"></location>
+        <source>Your TMD or Ticket may be damaged, or they may not correspond with the content being decrypted. If you have checked "Use local files, if they exist", try disabling that option before trying the download again to fix potential issues with local data.</source>
+        <translation>TMD-en eller billetten kan være skadet, eller det kan hende at de ikke samsvarer med innholdet som dekrypteres. Hvis du har krysset av for "Bruk lokale filer, hvis de finnes", kan du prøve å deaktivere dette alternativet før du prøver nedlastingen på nytt for å løse eventuelle problemer med lokale data.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="473"/>
+        <location filename="../../NUSGet.py" line="473"></location>
         <source>Ticket Not Available</source>
-        <translation>Billett Ikke Tilgjengelig</translation>
+        <translation>Billett ikke tilgjengelig</translation>
     </message>
     <message>
         <source>No Ticket is Available for the Requested Title!</source>
         <translation type="vanished">Ingen billett er tilgjengelig for den forespurte tittelen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="477"/>
-        <source>A ticket could not be downloaded for the requested title, but you have selected &quot;Pack installable archive&quot; or &quot;Create decrypted contents&quot;. These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
-        <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt &quot;Pakk installerbart arkiv&quot; eller &quot;Opprett dekryptert innhold&quot;. Disse alternativene er ikke tilgjenelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
+        <location filename="../../NUSGet.py" line="477"></location>
+        <source>A ticket could not be downloaded for the requested title, but you have selected "Pack installable archive" or "Create decrypted contents". These options are not available for titles without a ticket. Only encrypted contents have been saved.</source>
+        <translation>En billett kunne ikke lastes ned for den forespurte tittelen, men du har valgt "Pakk installerbart arkiv" eller "Opprett dekryptert innhold". Disse alternativene er ikke tilgjengelige for titler uten billett. Bare kryptert innhold har blitt lagret.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="479"/>
+        <location filename="../../NUSGet.py" line="479"></location>
         <source>Unknown Error</source>
-        <translation>Ukjent Feil</translation>
+        <translation>Ukjent feil</translation>
     </message>
     <message>
         <source>An Unknown Error has Occurred!</source>
         <translation type="vanished">En ukjent feil har oppstått!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="482"/>
+        <location filename="../../NUSGet.py" line="482"></location>
         <source>Please try again. If this issue persists, please open a new issue on GitHub detailing what you were trying to do when this error occurred.</source>
-        <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne et nytt issue på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
+        <translation>Prøv igjen. Hvis dette problemet vedvarer, åpne en ny saksrapport på GitHub med detaljer om hva du prøvde å gjøre da denne feilen oppstod.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="501"/>
+        <location filename="../../NUSGet.py" line="501"></location>
         <source>Script Issues Occurred</source>
-        <translation>Skriptfeil Oppstod</translation>
+        <translation>Skriptfeil oppstod</translation>
     </message>
     <message>
         <source>Some issues occurred while running the download script.</source>
         <translation type="vanished">Noen feil oppstod under kjøring av nedlastingsskriptet.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="504"/>
+        <location filename="../../NUSGet.py" line="504"></location>
         <source>Check the log for more details about what issues were encountered.</source>
         <translation>Sjekk loggen for mer informasjon om feilene som har oppstått.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="511"/>
+        <location filename="../../NUSGet.py" line="511"></location>
         <source>The following titles could not be downloaded due to an error. Please ensure that the Title ID and version listed in the script are valid.</source>
-        <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at Tittel IDen og versjon som er oppført i skriptet er gyldige.</translation>
+        <translation>Følgende titler kunne ikke lastes ned på grunn av en feil. Sjekk at tittel-ID-en og -versjonen som er oppført i skriptet er gyldige.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="521"/>
-        <source>You enabled &quot;Create decrypted contents&quot; or &quot;Pack installable archive&quot;, but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
-        <translation>Du aktiverte &quot;Opprett dekryptert innhold&quot; eller &quot;Pakk installerbart archive&quot;, men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
+        <location filename="../../NUSGet.py" line="521"></location>
+        <source>You enabled "Create decrypted contents" or "Pack installable archive", but the following titles in the script do not have tickets available. If enabled, encrypted contents were still downloaded.</source>
+        <translation>Du skrudde på "Opprett dekryptert innhold" eller "Pakk installerbart arkiv", men følgende titler i skriptet har ikke tilgjengelige billetter. Hvis aktivert, ble kryptert innhold fortsatt lastet ned.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="540"/>
+        <location filename="../../NUSGet.py" line="540"></location>
         <source>Script Download Failed</source>
-        <translation>Skriptnedlasting Mislyktes</translation>
+        <translation>Skriptnedlasting mislyktes</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="541"/>
+        <location filename="../../NUSGet.py" line="541"></location>
         <source>Open NUS Script</source>
-        <translation>Åpne NUS Skript</translation>
+        <translation>Åpne NUS-skript</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="542"/>
+        <location filename="../../NUSGet.py" line="542"></location>
         <source>NUS Scripts (*.nus *.json)</source>
-        <translation>NUS Skript (*.nus *.json)</translation>
+        <translation>NUS-skript (*.nus *.json)</translation>
     </message>
     <message>
         <source>An error occurred while parsing the script file!</source>
         <translation type="vanished">Det oppstod en feil under parsing av skriptfilen!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="554"/>
+        <location filename="../../NUSGet.py" line="554"></location>
         <source>Error encountered at line {lineno}, column {colno}. Please double-check the script and try again.</source>
         <translation></translation>
     </message>
@@ -564,59 +564,59 @@ Titler er lastes ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedl
         <translation type="vanished">Det oppstod en feil under parsing av Tittel IDer!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="565"/>
+        <location filename="../../NUSGet.py" line="565"></location>
         <source>The title at index {index} does not have a Title ID!</source>
-        <translation>Tittelen ved indeks {index} har ikke en Tittel ID!</translation>
+        <translation>Tittelen ved indeks {index} har ikke en tittel-ID!</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="618"/>
+        <location filename="../../NUSGet.py" line="618"></location>
         <source>Open Directory</source>
-        <translation>Åpen Mappe</translation>
+        <translation>Åpne mappe</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="629"/>
+        <location filename="../../NUSGet.py" line="629"></location>
         <source>&lt;b&gt;The specified download directory does not exist!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Den angitte nedlastingsmappen finnes ikke!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="632"/>
+        <location filename="../../NUSGet.py" line="632"></location>
         <source>Please make sure the download directory you want to use exists, and that you have permission to access it.</source>
-        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse fil å få tilgang til den.</translation>
+        <translation>Kontroller at den angitte nedlastingsmappen finnes, og at du har tillatelse til å få tilgang til den.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="226"/>
+        <location filename="../../NUSGet.py" line="226"></location>
         <source>Apply patches to IOS (Applies to WADs only)</source>
-        <translation>Påfør patcher på IOS (gjelder kun WADer)</translation>
+        <translation>Benytt patcher på IOS (gjelder kun WAD-er)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="119"/>
+        <location filename="../../NUSGet.py" line="119"></location>
         <source>Select a title from the list on the left, or enter a Title ID to begin.
 
 Titles marked with a checkmark are free and have a ticket available, and can be decrypted and/or packed into a WAD or TAD. Titles with an X do not have a ticket, and only their encrypted contents can be saved.
 
-By default, titles will be downloaded to a folder named &quot;NUSGet Downloads&quot; inside your downloads folder.</source>
-        <translation>Velg en tittel fra listen til venstre, eller skriv inn en Tittel ID for å begynne.
+By default, titles will be downloaded to a folder named "NUSGet Downloads" inside your downloads folder.</source>
+        <translation>Velg en tittel fra listen til venstre, eller skriv inn en tittel-ID for å begynne.
 
-Titler merket med en hake er fri og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X ikke har en billett, og bare det krypterte innholdet kan lagres.
+Titler merket med en hake er gratis og har en billett tilgjengelig, og kan dekrypteres og/eller pakkes inn i en WAD eller TAD. Titler med en X har ikke en billett, og bare det krypterte innholdet kan lagres.
 
-Som standard, lastes titler ned til en mappe med navnet &quot;NUSGet Downloads&quot; i nedlastingsmappen din.</translation>
+Som standard, lastes titler ned til en mappe med navnet "NUSGet Downloads" i nedlastingsmappen din.</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="224"/>
+        <location filename="../../NUSGet.py" line="224"></location>
         <source>Use the Wii U NUS (faster, only affects Wii/vWii)</source>
         <translation>Bruk Wii U NUS (raskere, påvirker bare Wii/vWii)</translation>
     </message>
     <message>
-        <location filename="../../NUSGet.py" line="305"/>
+        <location filename="../../NUSGet.py" line="305"></location>
         <source>NUSGet Update Available</source>
-        <translation>NUSGet Oppdatering Tilgjengelig</translation>
+        <translation>NUSGet-oppdatering tilgjengelig</translation>
     </message>
     <message>
-        <source>There&apos;s a newer version of NUSGet available!</source>
+        <source>There's a newer version of NUSGet available!</source>
         <translation type="vanished">Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="74"/>
+        <location filename="../../modules/core.py" line="74"></location>
         <source>
 
 Could not check for updates.</source>
@@ -625,19 +625,19 @@ Could not check for updates.</source>
 Kunne ikke sjekke for oppdateringer.</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="84"/>
+        <location filename="../../modules/core.py" line="84"></location>
         <source>
 
-There&apos;s a newer version of NUSGet available!</source>
+There's a newer version of NUSGet available!</source>
         <translation>
 
-Det finnes en nyere versjon av NUSGet tilgjengelig!</translation>
+En nyere versjon av NUSGet er tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../../modules/core.py" line="86"/>
+        <location filename="../../modules/core.py" line="86"></location>
         <source>
 
-You&apos;re running the latest release of NUSGet.</source>
+You're running the latest release of NUSGet.</source>
         <translation>
 
 Du kjører den nyeste versjonen av NUSGet.</translation>


### PR DESCRIPTION
Fixes:
* Various typos (Most visibly to Norwegians "instillinger", which is supposed to be "in**n**stillinger").
* Title casing (which is usually a no-no in Norwegian).
* Wrong tenses (e.g. "Run Script" being translated as "Kjøre Skript", which implies the user is inherently guaranteed to run it).
* At least 2 cases of what I can only presume is some bad parody of immigrant slang and/or stone age cavemen ("Du ikke har valgt" is roughly equivalent to "You not have chose").