### PR TITLE
Makefile changes Bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,16 @@ all:
 	$(CC) --show-progress --assume-yes-for-downloads NUSGet.py $(ARCH_FLAGS) -o NUSGet
 
 install:
-	rm -rd /opt/NUSGet/
+	rm -rf /opt/NUSGet/
 	install -d /opt/NUSGet
 	cp -r ./NUSGet.dist/* /opt/NUSGet/
 	chmod 755 /opt/NUSGet/
 	install ./packaging/icon.png /opt/NUSGet/NUSGet.png
 	install ./packaging/NUSGet.desktop /usr/share/applications
+
+uninstall:
+	rm -rf /opt/NUSGet
+	rm /usr/share/applications/NUSGet.desktop
 
 clean:
 	rm NUSGet


### PR DESCRIPTION
had an error when compiling that /opt/NUSGet cannot be found and therefore not be deleted. i fixed this by changing the `rm -rd /opt/NUSGet` line to `rm -rf /opt/NUSGet` since -f forces the deletion even if the file or directory does not exist and -r already includes the functionality of -d.
Furthermore i added an option to uninstall the program by running `sudo make uninstall`