### PR TITLE
Add note about `xcb` on X11 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For basic usage on all platforms, you can download the latest release for your o
 **Platform-Specific Notes:**
 - **macOS:** As of v1.4.3, NUSGet on macOS is signed with my Developer ID and can be run like any other Mac app.
 - **Windows:** On Windows, you'll likely need to allow NUSGet.exe in your antivirus program. This includes Windows Defender, which is almost guaranteed to prevent the app from being run. This is not because NUSGet is malicious in any way, it's just that NUSGet isn't popular enough to be "known" to Windows, and I don't have the expensive signing certificate necessary to work around this. If you're in doubt, you can look at all of NUSGet's code in this repository.
-- **Linux:** No special information applies on Linux, however you can build NUSGet yourself if you'd like to have it as an installed application with an icon that will appear in your favorite application launcher. See [here](https://github.com/NinjaCheetah/NUSGet?tab=readme-ov-file#for-linux-users) for more information.
+- **Linux:** If you're using X11, make sure to install the `xcb-cursor0` library (`libxcb-cursor0` on Ubuntu). You can build NUSGet yourself if you'd like to have it as an installed application with an icon that will appear in your favorite application launcher. See [here](https://github.com/NinjaCheetah/NUSGet?tab=readme-ov-file#for-linux-users) for more information.
 
 ## Building
 ### System Requirements


### PR DESCRIPTION
NUSGet on Linux with X11 requires `xcb-cursor0`, this PR adds a note about that to the README under the Linux platform notes. The specific package name for `apt` is `libxcb-cursor0`.

I double checked the conditions for the error in #44 on Linux Mint, which runs X11, and that looks to be the issue. I didn't test on any other distro with X11 (works fine with Wayland) so I haven't got a specific package name for other package managers.

I tried installing just plain `xcb`, but that failed with the same error and only worked with `xcb-cursor0` like mentioned in the issue.

Finalizes #44 